### PR TITLE
Fix permissions tombfile

### DIFF
--- a/src/tomb
+++ b/src/tomb
@@ -500,8 +500,8 @@ create_tomb() {
 
     # set permissions on the tomb
     ME=${SUDO_USER:-$(whoami)}
-    chmod 0600 ${tombfile}
-    chown $(id -u $ME):$(id -g $ME) ${tombfile}
+    chmod 0600 ${tombdir}/${tombfile}
+    chown $(id -u $ME):$(id -g $ME) ${tombdir}/${tombfile}
 
     act "done creating $tombname encrypted storage (using Luks dm-crypt AES/SHA256)"
     notice "Your tomb is ready in ${tombdir}/${tombfile} and secured with key ${tombfile}.key"


### PR DESCRIPTION
When creating tomb, create_tomb() tries to set permissions on that tomb as follow:

chmod 0600 ${tombfile}
chown $(id -u $ME):$(id -g $ME) ${tombfile}

but it fails:

$ ./tomb -s 10 create /home/user/graveyard/newtomb
[...]
[*] Setup your secret key file newtomb.tomb.key
 .  formatting Luks mapped device
 .  formatting your Tomb with Ext3/Ext4 filesystem
chmod: cannot access `newtomb.tomb': No such file or directory
chown: cannot access`newtomb.tomb': No such file or directory
[..]

This lines should be:

chmod 0600 ${tombdir}/${tombfile}
chown $(id -u $ME):$(id -g $ME) ${tombdir}/${tombfile}

and this branch uses the code above.
