### PR TITLE
fixed chown and chmod tomb file

### DIFF
--- a/src/tomb
+++ b/src/tomb
@@ -495,8 +495,8 @@ create_tomb() {
 
     # set permissions on the tomb
     ME=${SUDO_USER:-$(whoami)}
-    chmod 0600 ${tombfile}
-    chown $(id -u $ME):$(id -g $ME) ${tombfile}
+    chmod 0600 "${tombdir}/${tombfile}"
+    chown $(id -u $ME):$(id -g $ME) "${tombdir}/${tombfile}"
 
     act "done creating $tombname encrypted storage (using Luks dm-crypt AES/SHA256)"
     notice "Your tomb is ready in ${tombdir}/${tombfile} and secured with key ${tombfile}.key"


### PR DESCRIPTION
fixed chown and chmod tomb file path, that prevents from change the owner and permissions on newly created tomb.

For more details, see https://github.com/dyne/Tomb/issues/29
