### PR TITLE
Added steganography key support to 'open' command

### DIFF
--- a/src/tomb
+++ b/src/tomb
@@ -280,7 +280,7 @@ Options:
  -k     path to the key to use for opening a tomb
  -n     don't process the hooks found in tomb
  -o     mount options used to open (default: rw,noatime,nodev)
- --use-steg treat key file (-k) as a steganography key
+ --use-stegh treat key file (-k) as a steganography key
 
  -h     print this help
  -v     version information for this tool
@@ -533,7 +533,7 @@ mount_tomb() {
 	    tombkeydir=`safe_dir`
 	    cat > ${tombkeydir}/stdin.tmp
 	    tombkey=${tombkeydir}/stdin.tmp
-    elif option_is_set --use-steg ; then
+    elif option_is_set --use-stegh ; then
         decode_key `option_value -k` 
         if [[ $? == 1 ]]; then
             return 1
@@ -1236,7 +1236,7 @@ main() {
     #               (it will say "option defined more than once, and he's right)
     main_opts=(q -quiet=q D -debug=D h -help=h v -version=v)
     subcommands_opts[__default]=""
-    subcommands_opts[open]="n -nohook=n k: -key=k o: -mount-options=o -ignore-swap -use-steg"
+    subcommands_opts[open]="n -nohook=n k: -key=k o: -mount-options=o -ignore-swap -use-stegh"
     subcommands_opts[mount]=${subcommands_opts[open]}
     subcommands_opts[create]="s: -size=s -ignore-swap"
     subcommands_opts[close]=""


### PR DESCRIPTION
Added feature #11: added flag --use-stegh to 'open' command, that used in conjuction with -k, treat the key as a steganography image and automatically exhume the key and mount the tomb.
This feature modify sligly decode_key()
