### PR TITLE
Better exit code handling, #49

### DIFF
--- a/src/tomb
+++ b/src/tomb
@@ -1366,8 +1366,9 @@ main() {
 		 return 1
 		 ;;
     esac
-    return 0
+    return $?
 }
 
 check_bin
 main $@
+exit $?


### PR DESCRIPTION
Few line to address #49. It could not be the final solution, 'cause it doesn't check with care in the code for any point where "return 1" should be put. It just add the `exit $?` at the end
