### PR TITLE
Removing default mount point when umounting the tomb

### DIFF
--- a/src/tomb
+++ b/src/tomb
@@ -954,8 +954,11 @@ umount_tomb() {
 	umount ${tombmount}
 	if ! [ $? = 0 ]; then
 	    error "Tomb is busy, cannot umount!"
-	else
-	    rmdir ${tombmount}
+	else   
+        # this means we used a "default" mount point
+        if [ "${tombmount}" = "/media/${tombname}.tomb" ]; then
+	        rmdir ${tombmount}
+        fi
 	fi
     fi
 


### PR DESCRIPTION
When opening a tomb file without specifying a mount point, tomb script creates ones for you in /media/tombname.tomb.
When you umount the tomb, in this case, the desired behaviour was to remove the mount point: now, it does so.
