### PR TITLE
Tomb ignores the no exec hooks flag (-n)

### DIFF
--- a/src/tomb
+++ b/src/tomb
@@ -607,7 +607,7 @@ mount_tomb() {
     chown $(id -u $ME):$(id -g $ME) ${tombmount}
 
     notice "encrypted storage $tombfile succesfully mounted on $tombmount"
-    if ! [ $NOBIND ]; then
+    if ! option_is_set -n ; then
         exec_safe_bind_hooks ${tombmount}
         exec_safe_post_hooks ${tombmount} open
     fi
@@ -945,7 +945,7 @@ umount_tomb() {
     done
 
     # Execute post-hooks for eventual cleanup
-    if ! [ $NOBIND ]; then
+    if ! option_is_set -n ; then
 	    exec_safe_post_hooks ${tombmount%%/} close
     fi
 


### PR DESCRIPTION
The -n flag tells tomb to not execute pre-hooks and post-hooks: this was done by setting $NOBIND variable and check for its value.
$NOBIND should have been replaced by option_is_set() long time ago, now it's done and it works.
