### PR TITLE
Message formatting inconsistencies

### DIFF
--- a/tomb
+++ b/tomb
@@ -1071,7 +1071,7 @@ forge_key() {
     fi
 
     _success "Choose the password of your key: ${tombkey}"
-    _message "(You can also change it later using 'tomb passwd')"
+    _message "(You can also change it later using 'tomb passwd'.)"
     touch ${tombkey}
     chown ${_uid}:${_gid} ${tombkey}
     chmod 0600 ${tombkey}
@@ -1521,7 +1521,7 @@ mount_tomb() {
     chown ${_uid}:${_gid} ${tombmount}
     chmod 0750 ${tombmount}
 
-    _success "Success opening $tombfile on $fg_bold[white]$tombmount$fg_no_bold[white]."
+    _success "Success opening $tombfile on $fg_bold[white]$tombmount$fg_no_bold[white]"
 
     # print out when was opened the last time, by whom and where
     { test -r ${tombmount}/.last } && {
@@ -2332,7 +2332,7 @@ main() {
     if option_is_set -T; then _tty="`option_value -T`"; fi
 
     _verbose "Tomb command: $subcommand ${PARAM}"
-    _verbose "caller uid[$_uid] gid[$_gid] tty[$_tty]"
+    _verbose "Caller: uid[$_uid], gid[$_gid], tty[$_tty]."
 
     case "$subcommand" in
 


### PR DESCRIPTION
Some printed messages start with capital letter and some with small letter:

```
die "Error: the newly generated keyfile does not seem valid"
die "this operation requires a key file to be specified using the -k option"
```

Some messages end with a period, other don't:

```
die "No access to shared memory on this system, sorry."
die "No valid password supplied"
```

And finally, sometimes the long names of the output names are used, while other times the short ones are used:

```
_warning "Key not found, specify one using -k"
no "run 'tomb index' to create indexes"
```

I think it'd be good to have all the messages start with the same case, and end in the same way. Also, the code would be clearer if only one of the names of the output functions was used.
I could write a patch but I don't know what's the correct choice for each of the three inconsistencies.
