### PR TITLE
fixed incorrect help for dig command

### DIFF
--- a/tomb
+++ b/tomb
@@ -1156,7 +1156,7 @@ dig_tomb() {
     _success "Done digging $tombname"
     _message "your tomb is not yet ready, you need to forge a key and lock it:"
     _message "tomb forge ${tombname}.tomb.key"
-    _message "tomb lock ${tombname}.tomb ${tombname}.tomb.key"
+    _message "tomb lock ${tombname}.tomb -k ${tombname}.tomb.key"
 }
 
 


### PR DESCRIPTION
After the execution of "dig" command for new files, the help display the following message

```
tomb (*) Done digging test
tomb  .  your tomb is not yet ready, you need to forge a key and lock it:
tomb  .  tomb forge test.tomb.key
tomb  .  tomb lock test.tomb test.tomb.key
```

But the correct command should be

```
tomb  .  tomb lock test.tomb -k test.tomb.key
```
