### PR TITLE
fixed 'non interactive' e2fsck on resize, proposal for #111

### DIFF
--- a/tomb
+++ b/tomb
@@ -2036,7 +2036,7 @@ resize_tomb() {
 	_failure "cryptsetup failed to resize $mapper"
     fi
 
-    e2fsck -f /dev/mapper/${mapper}
+    e2fsck -p -f /dev/mapper/${mapper}
     if [ $? != 0 ]; then
 	losetup -d ${nstloop}
 	_failure "e2fsck failed to check $mapper"


### PR DESCRIPTION
Simply adding "-p" option to e2fsck the exit status for resize command is 0
