### PR TITLE
Spanish translations updated

### DIFF
--- a/extras/po/de.po
+++ b/extras/po/de.po
@@ -20,20 +20,12 @@ msgid "Operation aborted."
 msgstr "Vorgang abgebrochen."
 
 #: _verbose
-msgid "exec_as_user '::1 user::': ::2::"
-msgstr "exec_as_user '::1 user::': ::2::"
-
-#: _verbose
 msgid "Using sudo for root execution of '::1 exec:: ::2 args::'."
 msgstr "Benutzen von sudo um '::1 exec:: ::2 args::' als root auszuführen."
 
 #: _verbose
 msgid "Escalating privileges using sudo-pwd."
 msgstr "Berechtigungskonflikte beim Benutzen von sudo-pwd."
-
-#: _verbose
-msgid "is_valid_tomb ::1 tomb file::"
-msgstr "is_valid_tomb ::1 tomb file::"
 
 #: _warning
 msgid "Tomb file is missing from arguments."
@@ -77,43 +69,25 @@ msgstr "Loop-Mount der Laufwerke nicht unterstützt, dieser Fehler"
 
 #: _warning
 msgid "often occurs on VPS and kernels that don't provide the loop module."
-msgstr "tritt oft in virtuellen Maschinen auf oder mit Kerneln ohne Loop-Modul."
+msgstr ""
+"tritt oft in virtuellen Maschinen auf oder mit Kerneln ohne Loop-Modul."
 
 #: _warning
 msgid "It is impossible to use Tomb on this machine at this conditions."
-msgstr "Es ist unmöglich Tomb unter diesen Umständen auf dieser Maschine zu benutzen."
+msgstr ""
+"Es ist unmöglich Tomb unter diesen Umständen auf dieser Maschine zu benutzen."
 
 #: _verbose
 msgid "lo_preserve on ::1 path::"
 msgstr "lo_preserve on ::1 path::"
 
 #: _verbose
-msgid "tomb_file: ::1 tomb file::"
-msgstr "tomb_file: ::1 tomb file::"
-
-#: _verbose
 msgid "tomb_key: ::1 key:: chars long"
 msgstr "tomb_key: ::1 key:: Zeichen lang"
 
 #: _verbose
-msgid "tomb_key_file: ::1 key::"
-msgstr "tomb_key_file: ::1 key::"
-
-#: _verbose
 msgid "tomb_secret: ::1 secret:: chars long"
 msgstr "tomb_secret: ::1 secret:: Zeichen lang"
-
-#: _verbose
-msgid "tomb_password: ::1 tomb pass::"
-msgstr "tomb_password: ::1 tomb pass::"
-
-#: _verbose
-msgid "tomb_tempfiles: ::1 temp files::"
-msgstr "tomb_tempfiles: ::1 temp files::"
-
-#: _verbose
-msgid "tomb_loopdevs: ::1 loopdevs::"
-msgstr "tomb_loopdevs: ::1 loopdevs::"
 
 #: _print
 msgid "Syntax: tomb [options] command [arguments]"
@@ -201,11 +175,14 @@ msgstr "Optionen:"
 
 #: _print
 msgid " -s     size of the tomb file when creating/resizing one (in MB)"
-msgstr " -s        Größe eines Grabes (beim Erstellen/neue Größe zuweisen) (in Mb)"
+msgstr ""
+" -s        Größe eines Grabes (beim Erstellen/neue Größe zuweisen) (in Mb)"
 
 #: _print
 msgid " -k     path to the key to be used ('-k -' to read from stdin)"
-msgstr " -k        Dateipfad zum Schlüssel ('-k -' um ihn aus der Standarteingabe einzulesen)"
+msgstr ""
+" -k        Dateipfad zum Schlüssel ('-k -' um ihn aus der Standarteingabe "
+"einzulesen)"
 
 #: _print
 msgid " -n     don't process the hooks found in tomb"
@@ -229,7 +206,9 @@ msgstr " -h        Anzeigen dieses Hilfetextes"
 
 #: _print
 msgid " -v     print version, license and list of available ciphers"
-msgstr " -v        Anzeigen der Version, Lizenzen und vorhandeners Verschlüsslungsmethoden"
+msgstr ""
+" -v        Anzeigen der Version, Lizenzen und vorhandeners "
+"Verschlüsslungsmethoden"
 
 #: _print
 msgid " -q     run quietly without printing informations"
@@ -249,11 +228,9 @@ msgstr "Bug-Reports bitte an <https://github.com/dyne/tomb/issues>.."
 
 #: _failure
 msgid "Cannot find ::1::. It's a requirement to use Tomb, please install it."
-msgstr "Kann ::1:: nicht finden. Bitte installieren, da es zum Funktionement von Tomb benötigt wird."
-
-#: _verbose
-msgid "is_valid_key"
-msgstr "is_valid_key"
+msgstr ""
+"Kann ::1:: nicht finden. Bitte installieren, da es zum Funktionement von "
+"Tomb benötigt wird."
 
 #: _warning
 msgid "is_valid_key() called without argument."
@@ -273,7 +250,8 @@ msgstr "Versuche Schlüssel wieder herzustellen"
 
 #: _failure
 msgid "This operation requires a key file to be specified using the -k option."
-msgstr "Diese Operation benötigt das angeben eines Schlüssels durch die -k Option."
+msgstr ""
+"Diese Operation benötigt das angeben eines Schlüssels durch die -k Option."
 
 #: _verbose
 msgid "load_key reading from stdin."
@@ -291,25 +269,16 @@ msgstr "load_key argument: ::1 opt::"
 msgid "Key not found, specify one using -k."
 msgstr "Schlüssel nicht gefunden, bitte mit -k einen Schlüssel angeben."
 
-#: _verbose
-msgid "load_key: ::1 key::"
-msgstr "load_key: ::1 key::"
-
 #: _warning
-msgid "The key seems invalid or its format is not known by this version of Tomb."
-msgstr "Der Schlüssel scheint ungültig zu sein, oder sein Format ist dieser Tomb Version unbekannt."
+msgid ""
+"The key seems invalid or its format is not known by this version of Tomb."
+msgstr ""
+"Der Schlüssel scheint ungültig zu sein, oder sein Format ist dieser Tomb "
+"Version unbekannt."
 
 #: _verbose
 msgid "GnuPG is version 1.4.11 - adopting status fix."
 msgstr "GnuPG Version 1.4.11 - bessere Status aus"
-
-#: _verbose
-msgid "get_lukskey"
-msgstr "get_lukskey"
-
-#: _verbose
-msgid "KDF: ::1 kdf::"
-msgstr "Schlüsselableitungsfunktion: ::1 kdf::"
 
 #: _failure
 msgid "No suitable program for KDF ::1 program::."
@@ -347,17 +316,9 @@ msgstr "Benutzer hat Passwort für Schlüssel ::1 key:: gewechselt."
 msgid "Changing password for ::1 key file::"
 msgstr "Passwort gewechselt für ::1 key file::."
 
-#: _verbose
-msgid "tomb-old-pwd = ::1 old pass::"
-msgstr "tomb-old-pwd = ::1 old pass::"
-
 #: _failure
 msgid "No valid password supplied."
 msgstr "Kein gültiges Passwort angegeben"
-
-#: _verbose
-msgid "tomb-pwd = ::1 new pass::"
-msgstr "tomb-pwd = ::1 new pass::"
 
 #: _failure
 msgid "Error: the newly generated keyfile does not seem valid."
@@ -380,7 +341,8 @@ msgid "gen_key takes tombpass from CLI argument: ::1 tomb pass::"
 msgstr "gen_key nimmt Passwort von der Kommandozeile an: ::1 tomb pass::"
 
 #: _failure
-msgid "Wrong argument for --kdf: must be an integer number (iteration seconds)."
+msgid ""
+"Wrong argument for --kdf: must be an integer number (iteration seconds)."
 msgstr "Ungültiges Argument für --kdf:dies muss eine Ganzzahl sein."
 
 #: _success
@@ -401,7 +363,8 @@ msgstr "Passwort verschlüsseln"
 
 #: _failure
 msgid "gpg (GnuPG) is not found, Tomb cannot function without it."
-msgstr "gpg (GnuPG) welches zur Funktion von Tomb notwendig ist, nicht gefunden."
+msgstr ""
+"gpg (GnuPG) welches zur Funktion von Tomb notwendig ist, nicht gefunden."
 
 #: _failure
 msgid "Bury failed for invalid key: ::1 key::"
@@ -419,17 +382,14 @@ msgstr "Verschlüssleung des Schlüssels ::1 tomb key:: im Bild ::2 image file::
 msgid "Please confirm the key password for the encoding"
 msgstr "Bitte bestätigen Sie das Passwort zur Verschlüsselung"
 
-#: _verbose
-msgid "tomb-pwd = ::1 tomb pass::"
-msgstr "tomb-pwd = ::1 tomb pass::"
-
 #: _warning
 msgid "Wrong password supplied."
 msgstr "Das eingegebene Passwort ist falsch."
 
 #: _failure
 msgid "You shall not bury a key whose password is unknown to you."
-msgstr "Sie dürfen keinen Schlüssel vergraben, von dem Sie das Passwort nicht kennen."
+msgstr ""
+"Sie dürfen keinen Schlüssel vergraben, von dem Sie das Passwort nicht kennen."
 
 #: _warning
 msgid "Encoding error: steghide reports problems."
@@ -437,7 +397,9 @@ msgstr "Fehler beim Verschlüsseln: steghide meldet Fehler."
 
 #: _success
 msgid "Tomb key encoded succesfully into image ::1 image file::"
-msgstr "Der Schlüssel des Grabes wurde erfolgreich im Bild ::1 image file:: verschlüsselt."
+msgstr ""
+"Der Schlüssel des Grabes wurde erfolgreich im Bild ::1 image file:: "
+"verschlüsselt."
 
 #: _message
 msgid "printing exhumed key on stdout"
@@ -500,7 +462,9 @@ msgstr "Vorgang erfolgreich:"
 
 #: _warning
 msgid "A filename needs to be specified using -k to forge a new key."
-msgstr "Mit -k muss ein Dateiname angegeben werden, um einen neuen Schlüssel zu schmieden."
+msgstr ""
+"Mit -k muss ein Dateiname angegeben werden, um einen neuen Schlüssel zu "
+"schmieden."
 
 #: _message
 msgid "Commanded to forge key ::1 key::"
@@ -508,31 +472,37 @@ msgstr "::1 key:: wird geschmiedet"
 
 #: _warning
 msgid "Forging this key would overwrite an existing file. Operation aborted."
-msgstr "Diesen Schlüssel zu schmieden würde eine existierende Datei überschreiben. Aktion abgebrochen."
-
-#: _failure
-msgid "`ls -lh $destkey`"
-msgstr "`ls -lh $destkey`"
+msgstr ""
+"Diesen Schlüssel zu schmieden würde eine existierende Datei überschreiben. "
+"Aktion abgebrochen."
 
 #: _message
 msgid "Commanded to forge key ::1 key:: with cipher algorithm ::2 algorithm::"
-msgstr "Der Schlüssel ::1 key:: wird mit dem Verschlüsselungsalgorithmus ::2 algorithm:: geschmiedet."
+msgstr ""
+"Der Schlüssel ::1 key:: wird mit dem Verschlüsselungsalgorithmus ::2 "
+"algorithm:: geschmiedet."
 
 #: _message
 msgid "This operation takes time, keep using this computer on other tasks,"
-msgstr "Dieser Vorgang braucht Zeit, benutzen Sie den Computer für andere Aufgaben,"
+msgstr ""
+"Dieser Vorgang braucht Zeit, benutzen Sie den Computer für andere Aufgaben,"
 
 #: _message
 msgid "once done you will be asked to choose a password for your tomb."
-msgstr "wenn der Vorgang einmal abgeschlossen ist, werden Sie gefragt ein Passwort für ihr Grab anzugeben."
+msgstr ""
+"wenn der Vorgang einmal abgeschlossen ist, werden Sie gefragt ein Passwort "
+"für ihr Grab anzugeben."
 
 #: _message
 msgid "To make it faster you can move the mouse around."
-msgstr "Um den Vorgang zu Beschleunigen können Sie die Maus hin und her bewegen."
+msgstr ""
+"Um den Vorgang zu Beschleunigen können Sie die Maus hin und her bewegen."
 
 #: _message
 msgid "If you are on a server, you can use an Entropy Generation Daemon."
-msgstr "Falls Sie auf einem Server sind können Sie einen Daemon benutzen um Entropie zu erstellen."
+msgstr ""
+"Falls Sie auf einem Server sind können Sie einen Daemon benutzen um Entropie "
+"zu erstellen."
 
 #: _verbose
 msgid "Data dump using ::1:: from ::2 source::"
@@ -557,10 +527,6 @@ msgstr "Der Schlüssel scheint ungültig zu sein."
 #: _warning
 msgid "Dumping contents to screen:"
 msgstr "Inhalte werden am Bildschirm angezeigt :"
-
-#: _warning
-msgid "--"
-msgstr "--"
 
 #: _message
 msgid "Done forging ::1 key::"
@@ -594,10 +560,6 @@ msgstr "Die minimale Größe ist 10 Mb."
 msgid "A tomb exists already. I'm not digging here:"
 msgstr "Es existiert bereits ein Grab. Hier grabe ich nicht:"
 
-#: _warning
-msgid " `ls -lh ${tombdir}/${tombfile}`"
-msgstr " `ls -lh ${tombdir}/${tombfile}`"
-
 #: _success
 msgid "Creating a new tomb in ::1 tomb dir::/::2 tomb file::"
 msgstr "Neues Grab in ::1 tomb dir::/::2 tomb file::"
@@ -611,8 +573,11 @@ msgid "Data dump using ::1:: from /dev/urandom"
 msgstr "Datenausgabe mit ::1:: von /dev/urandom"
 
 #: _failure
-msgid "Error creating the tomb ::1 tomb dir::/::2 tomb file::, operation aborted."
-msgstr "Fehler beim Erstellen des Grabes ::1 tomb dir::/::2 tomb file::. Vorgang abgebrochen."
+msgid ""
+"Error creating the tomb ::1 tomb dir::/::2 tomb file::, operation aborted."
+msgstr ""
+"Fehler beim Erstellen des Grabes ::1 tomb dir::/::2 tomb file::. Vorgang "
+"abgebrochen."
 
 #: _success
 msgid "Done digging ::1 tomb name::"
@@ -620,15 +585,9 @@ msgstr "Das Grab ::1 tomb name:: wurde ausgehoben."
 
 #: _message
 msgid "Your tomb is not yet ready, you need to forge a key and lock it:"
-msgstr "Ihr Grab ist noch nicht bereit, erst müssen Sie einen Schlüssel schmieden und es abschließen:"
-
-#: _message
-msgid "tomb forge ::1 tomb name::.tomb.key"
-msgstr "tomb forge ::1 tomb name::.tomb.key"
-
-#: _message
-msgid "tomb lock ::1 tomb name::.tomb -k ::1 tomb name::.tomb.key"
-msgstr "tomb lock ::1 tomb name::.tomb -k ::1 tomb name::.tomb.key"
+msgstr ""
+"Ihr Grab ist noch nicht bereit, erst müssen Sie einen Schlüssel schmieden "
+"und es abschließen:"
 
 #: _warning
 msgid "No tomb specified for locking."
@@ -656,15 +615,19 @@ msgstr "Loop mount in::1 mount point::"
 
 #: _message
 msgid "Checking if the tomb is empty (we never step on somebody else's bones)."
-msgstr "Am kontrollieren ob Grab leer ist (wir würden nie fremde Knochen stören)."
+msgstr ""
+"Am kontrollieren ob Grab leer ist (wir würden nie fremde Knochen stören)."
 
 #: _warning
 msgid "The tomb was already locked with another key."
 msgstr "Grab ist schon mit anderem Schlüssel verschlossen."
 
 #: _failure
-msgid "Operation aborted. I cannot lock an already locked tomb. Go dig a new one."
-msgstr "Vorgang abgebrochen. Ich kann kein bereits abgeschlossenes Grab nochmal abschließen. Graben Sie ein neues."
+msgid ""
+"Operation aborted. I cannot lock an already locked tomb. Go dig a new one."
+msgstr ""
+"Vorgang abgebrochen. Ich kann kein bereits abgeschlossenes Grab nochmal "
+"abschließen. Graben Sie ein neues."
 
 #: _message
 msgid "Fine, this tomb seems empty."
@@ -708,11 +671,17 @@ msgstr "Ihr Grab ::1 tomb file:: könnte korrumpiert sein."
 
 #: _message
 msgid "Done locking ::1 tomb name:: using Luks dm-crypt ::2 cipher::"
-msgstr "Grab ::1 tomb name:: wurde erfolgreich verschlüsselt mit LUKS dm-crypt ::2 cipher::"
+msgstr ""
+"Grab ::1 tomb name:: wurde erfolgreich verschlüsselt mit LUKS dm-crypt ::2 "
+"cipher::"
 
 #: _success
-msgid "Your tomb is ready in ::1 tomb dir::/::2 tomb file:: and secured with key ::3 tomb key::"
-msgstr "Ihr Grab ist unter ::1 tomb dir::/::2 tomb file:: bereit und mit Schlüssel ::3 tomb key:: geschützt"
+msgid ""
+"Your tomb is ready in ::1 tomb dir::/::2 tomb file:: and secured with "
+"key ::3 tomb key::"
+msgstr ""
+"Ihr Grab ist unter ::1 tomb dir::/::2 tomb file:: bereit und mit "
+"Schlüssel ::3 tomb key:: geschützt"
 
 #: _message
 msgid "Commanded to reset key for tomb ::1 tomb name::"
@@ -720,7 +689,9 @@ msgstr "Schlüssel wird zurückgesetzt für Grab ::1 tomb name::"
 
 #: _warning
 msgid "Command 'setkey' needs two arguments: the old key file and the tomb."
-msgstr "Der Befehl 'setkey' benötigt zwei Argumente: Die alte Schlüsseldatei und das Grab."
+msgstr ""
+"Der Befehl 'setkey' benötigt zwei Argumente: Die alte Schlüsseldatei und das "
+"Grab."
 
 #: _warning
 msgid "I.e:  tomb -k new.tomb.key old.tomb.key secret.tomb"
@@ -736,7 +707,9 @@ msgstr "Dieses Grab ist ein gültiges LUKS verschlüsseltes Gerät: ::1 volume::
 
 #: _failure
 msgid "Aborting operations: error loading old key from arguments"
-msgstr "Operationen abgebrochen: Fehler beim Laden des alten Schlüssels aus den Argumenten"
+msgstr ""
+"Operationen abgebrochen: Fehler beim Laden des alten Schlüssels aus den "
+"Argumenten"
 
 #: _success
 msgid "Changing lock on tomb ::1 tomb name::"
@@ -782,13 +755,10 @@ msgstr "Der Schlüssel wurde erfolgreich gewechselt am Grab ::1 tomb file::"
 msgid "The new key is: ::1 new key::"
 msgstr "Der neue Schlüssel ist: ::1 new key::"
 
-#: _verbose
-msgid "create_tomb(): ::1:: ::2::"
-msgstr "create_tomb(): ::1:: ::2::"
-
 #: _warning
 msgid "Creating this tomb would overwrite an existing file."
-msgstr "Das ausheben dieses Grabes würde eine existierende Datei überschreiben."
+msgstr ""
+"Das ausheben dieses Grabes würde eine existierende Datei überschreiben."
 
 #: _failure
 msgid "Failed to forge key, operation aborted."
@@ -796,7 +766,9 @@ msgstr "Schlüssel schmieden fehlgeschlagen, Operation abgebrochen."
 
 #: _failure
 msgid "Failed to lock tomb with key, operation aborted."
-msgstr "Abschliessen des Grabes mit dem Schlüssel fehlgeschlagen, Operation abgebrochen."
+msgstr ""
+"Abschliessen des Grabes mit dem Schlüssel fehlgeschlagen, Operation "
+"abgebrochen."
 
 #: _success
 msgid "Tomb ::1 tomb name:: succesfully created."
@@ -816,7 +788,8 @@ msgstr "::1 tomb file:: ist keine gültige Grab Datei, Operation abgebrochen."
 
 #: _failure
 msgid "Aborting operations: error loading key ::1 key::"
-msgstr "Operationen werden abgebrochen: Fehler beim Laden des Schlüssels ::1 key::"
+msgstr ""
+"Operationen werden abgebrochen: Fehler beim Laden des Schlüssels ::1 key::"
 
 #: _message
 msgid "Mountpoint not specified, using default: ::1 mount point::"
@@ -844,11 +817,16 @@ msgstr "Dieses Grab ist ein gültiges LUKS verschlüsseltes Gerät."
 
 #: _message
 msgid "Cipher is \"::1 cipher::\" mode \"::2 mode::\" hash \"::3 hash::\""
-msgstr "Verschlüsselung \"::1 cipher::\" im Modus \"::2 mode::\" und der Hashfunktion \"::3 hash::\"."
+msgstr ""
+"Verschlüsselung \"::1 cipher::\" im Modus \"::2 mode::\" und der "
+"Hashfunktion \"::3 hash::\"."
 
 #: _warning
-msgid "Multiple key slots are enabled on this tomb. Beware: there can be a backdoor."
-msgstr "Mehrere Schlüssellöcher sind an diesem Grab angebracht. Achtung, es könnte eine Hintertür geben."
+msgid ""
+"Multiple key slots are enabled on this tomb. Beware: there can be a backdoor."
+msgstr ""
+"Mehrere Schlüssellöcher sind an diesem Grab angebracht. Achtung, es könnte "
+"eine Hintertür geben."
 
 #: _verbose
 msgid "dev mapper device: ::1 mapper::"
@@ -888,7 +866,8 @@ msgstr "::1 tomb file:: erfolgreich geöffnet in ::2 mount point::"
 
 #: _message
 msgid "Last visit by ::1 user::(::2 tomb build::) from ::3 tty:: on ::4 host::"
-msgstr "Letzer Besuch von ::1 user::(::2 tomb build::) von ::3 tty:: auf ::4 host::"
+msgstr ""
+"Letzer Besuch von ::1 user::(::2 tomb build::) von ::3 tty:: auf ::4 host::"
 
 #: _message
 msgid "on date ::1 date::"
@@ -912,15 +891,20 @@ msgstr "'bind hooks' map format: local/to/tomb local/to/$HOME"
 
 #: _warning
 msgid "bind-hooks map format: local/to/tomb local/to/$HOME.  Rolling back"
-msgstr "'bind-hooks' map format: local/to/tomb local/to/$HOME.  Wird rückgängig gemacht"
+msgstr ""
+"'bind-hooks' map format: local/to/tomb local/to/$HOME.  Wird rückgängig "
+"gemacht"
 
 #: _warning
 msgid "bind-hook target not existent, skipping ::1 home::/::2 subdir::"
 msgstr "'bind-hooks' Ziel ungültig,  ::1 home::/::2 subdir:: wird ignoriert."
 
 #: _warning
-msgid "bind-hook source not found in tomb, skipping ::1 mount point::/::2 subdir::"
-msgstr "'bind-hooks' Quelle nicht in Grab gefunden, ::1 mount point::/::2 subdir:: wird ignoriert"
+msgid ""
+"bind-hook source not found in tomb, skipping ::1 mount point::/::2 subdir::"
+msgstr ""
+"'bind-hooks' Quelle nicht in Grab gefunden, ::1 mount point::/::2 subdir:: "
+"wird ignoriert"
 
 #: _success
 msgid "Post hooks found, executing as user ::1 user name::."
@@ -936,7 +920,9 @@ msgstr "Interner fehler: list_tomb_binds ohne rgumente aufgerufen."
 
 #: _failure
 msgid "Cannot index tombs on this system: updatedb (mlocate) not installed."
-msgstr "Kann Gräber auf diesem System nicht indexieren: updatedb (mlocate) nicht installiert."
+msgstr ""
+"Kann Gräber auf diesem System nicht indexieren: updatedb (mlocate) nicht "
+"installiert."
 
 #: _warning
 msgid "Cannot use GNU findutils for index/search commands."
@@ -945,10 +931,6 @@ msgstr "Kann GNU findutils nicht für Indexierung/Suchbefehle benutzen."
 #: _failure
 msgid "Index command needs 'mlocate' to be installed."
 msgstr "Index Befehl benötigt installiertes 'mlocate'"
-
-#: _verbose
-msgid "$updatedbver"
-msgstr "$updatedbver"
 
 #: _failure
 msgid "There seems to be no open tomb engraved as [::1::]"
@@ -1052,7 +1034,9 @@ msgstr "Die neue Grösse muss grösser sein als die alte."
 
 #: _failure
 msgid "Error creating the extra resize ::1 size::, operation aborted."
-msgstr "Fehler beim erstellen der extra Vergrösserung ::1 size::, Operation abgebrochen."
+msgstr ""
+"Fehler beim erstellen der extra Vergrösserung ::1 size::, Operation "
+"abgebrochen."
 
 #: _failure
 msgid "cryptsetup failed to resize ::1 mapper::"
@@ -1072,7 +1056,8 @@ msgstr "Es gibt kein zu schließendes Grab."
 
 #: _warning
 msgid "Too many tombs mounted, please specify one (see tomb list)"
-msgstr "Zu viele Gräber geöffnet, bitte geben sie ein Grab an (siehe 'tomb list')"
+msgstr ""
+"Zu viele Gräber geöffnet, bitte geben sie ein Grab an (siehe 'tomb list')"
 
 #: _warning
 msgid "or issue the command 'tomb close all' to close them all."
@@ -1104,7 +1089,9 @@ msgstr "Bitte geben Sie ein existierendes Grab an."
 
 #: _success
 msgid "Slamming tomb ::1 tomb name:: mounted on ::2 mount point::"
-msgstr "Das Grab ::1 tomb name:: eingehängt auf ::2 mount point:: wurde abrupt geschlossen."
+msgstr ""
+"Das Grab ::1 tomb name:: eingehängt auf ::2 mount point:: wurde abrupt "
+"geschlossen."
 
 #: _message
 msgid "Kill all processes busy inside the tomb."
@@ -1132,7 +1119,8 @@ msgstr "Abruptes schliessen des 'bind hooks' ::1 hook:: nicht möglich"
 
 #: _warning
 msgid "Tomb bind hook ::1 hook:: is busy, cannot close tomb."
-msgstr "Der 'bind hook' ::1 hook:: ist beschäftigt und kann nicht geschlossen werden."
+msgstr ""
+"Der 'bind hook' ::1 hook:: ist beschäftigt und kann nicht geschlossen werden."
 
 #: _verbose
 msgid "Performing umount of ::1 mount point::"
@@ -1144,11 +1132,15 @@ msgstr "Grab ist beschäftigt und kann nicht ausgehänkt werden !"
 
 #: _warning
 msgid "Error occurred in cryptsetup luksClose ::1 mapper::"
-msgstr "Ein Fehler ist beim Ausführen von 'cryptsetup luksClose ::1 mapper::' aufgetreten."
+msgstr ""
+"Ein Fehler ist beim Ausführen von 'cryptsetup luksClose ::1 mapper::' "
+"aufgetreten."
 
 #: _success
 msgid "Tomb ::1 tomb name:: closed: your bones will rest in peace."
-msgstr "Das Grab ::1 tomb name:: ist abgeschlossen, mögen ihre Knochen in Frieden ruhen."
+msgstr ""
+"Das Grab ::1 tomb name:: ist abgeschlossen, mögen ihre Knochen in Frieden "
+"ruhen."
 
 #: _verbose
 msgid "Sending ::1:: to processes inside the tomb:"
@@ -1179,8 +1171,14 @@ msgid "Unrecognized option ::1 arg:: for subcommand ::2 subcommand::"
 msgstr "Unbekannte Option ::1 arg:: für Unterbefehl ::2 subcommand::"
 
 #: _failure
-msgid "You specified option ::1 option::, which is DANGEROUS and should only be used for testing\nIf you really want so, add --unsecure-dev-mode"
-msgstr "Sie haben die Option ::1 option:: gewählt welche GEFÄHRLICH ist, und nur für Tests verwendet werden soll\nWenn Sie sie wirklich benutzen wollen, fügen Sie --unsecure-dev-mode hinzu"
+msgid ""
+"You specified option ::1 option::, which is DANGEROUS and should only be "
+"used for testing\n"
+"If you really want so, add --unsecure-dev-mode"
+msgstr ""
+"Sie haben die Option ::1 option:: gewählt welche GEFÄHRLICH ist, und nur für "
+"Tests verwendet werden soll\n"
+"Wenn Sie sie wirklich benutzen wollen, fügen Sie --unsecure-dev-mode hinzu"
 
 #: _verbose
 msgid "Tomb command: ::1 subcommand:: ::2 param::"
@@ -1195,8 +1193,11 @@ msgid "QREncode not installed: cannot engrave keys on paper."
 msgstr "QREncode nicht installiert: Kann Grabgravur nicht auf Papier ausgeben."
 
 #: _warning
-msgid "The create command is deprecated, please use dig, forge and lock instead."
-msgstr "Der Befehl create ist veraltet, benutzen Sie stattdesseb dig, forge, und lock."
+msgid ""
+"The create command is deprecated, please use dig, forge and lock instead."
+msgstr ""
+"Der Befehl create ist veraltet, benutzen Sie stattdesseb dig, forge, und "
+"lock."
 
 #: _warning
 msgid "For more informations see Tomb's manual page (man tomb)."
@@ -1204,11 +1205,15 @@ msgstr "Für mehr Informationen siehe Benutzerhandbuch (man tomb)."
 
 #: _failure
 msgid "Steghide not installed: cannot bury keys into images."
-msgstr "Steghide ist nicht installiert: Schlüssel können nicht in Bilder vergraben werden."
+msgstr ""
+"Steghide ist nicht installiert: Schlüssel können nicht in Bilder vergraben "
+"werden."
 
 #: _failure
 msgid "Steghide not installed: cannot exhume keys from images."
-msgstr "Steghide ist nicht installiert: Schlüssel können nicht aus Bilder ausgegraben werden."
+msgstr ""
+"Steghide ist nicht installiert: Schlüssel können nicht aus Bilder "
+"ausgegraben werden."
 
 #: _failure
 msgid "Resize2fs not installed: cannot resize tombs."
@@ -1216,7 +1221,8 @@ msgstr "Resize2fs nicht installiert: Gräber können nicht vergrössert werden."
 
 #: _print
 msgid "Tomb ::1 version:: - a strong and gentle undertaker for your secrets"
-msgstr "Tomb ::1 version:: - ein starker und sanfter Totengräber für ihre Geheimnisse"
+msgstr ""
+"Tomb ::1 version:: - ein starker und sanfter Totengräber für ihre Geheimnisse"
 
 #: _print
 msgid " Copyright (C) 2007-2014 Dyne.org Foundation, License GNU GPL v3+"
@@ -1224,7 +1230,8 @@ msgstr " Urheberrecht (C) 2007-2014 Dyne.org Foundation, Lizens GNU GPL v3+"
 
 #: _print
 msgid " This is free software: you are free to change and redistribute it"
-msgstr " This ist freie Software, Sie sind frei sie zu verändern und weiterzugeben"
+msgstr ""
+" This ist freie Software, Sie sind frei sie zu verändern und weiterzugeben"
 
 #: _print
 msgid " The latest Tomb sourcecode is published on <http://tomb.dyne.org>"
@@ -1232,7 +1239,8 @@ msgstr "Der neueste Quellcode ist auf <http://tomb.dyne.org> erhältlich"
 
 #: _print
 msgid " This source code is distributed in the hope that it will be useful,"
-msgstr " Dieser Quellcode wird veröffentlicht in der Hoffnung dass er nützlich ist,"
+msgstr ""
+" Dieser Quellcode wird veröffentlicht in der Hoffnung dass er nützlich ist,"
 
 #: _print
 msgid " but WITHOUT ANY WARRANTY; without even the implied warranty of"
@@ -1244,7 +1252,8 @@ msgstr " MARKTGÄNGIGKEIT oder der EIGNUNG ZU EINEM BESTIMMTEN ZWECK."
 
 #: _print
 msgid " Please refer to the GNU Public License for more details."
-msgstr " Bitte beziehen Sie sich auf die \"GNU Public License\" für mehr Details.""
+msgstr ""
+" Bitte beziehen Sie sich auf die \"GNU Public License\" für mehr Details."
 
 #: _print
 msgid "System utils:"

--- a/extras/po/es.po
+++ b/extras/po/es.po
@@ -8,9 +8,8 @@ msgstr ""
 "Project-Id-Version: Tomb \n"
 "PO-Revision-Date: sáb ago 30 20:56:52 CEST 2014\n"
 "Last-Translator: Dani \"GDrooid\" <gdrooid@openmailbox.org>\n"
-"Language: Spanish\n"
 "Language-Team: Tomb developers <crypto@lists.dyne.org>\n"
-"Language: \n"
+"Language: Spanish\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -28,20 +27,13 @@ msgid "Operation aborted."
 msgstr "Operación abortada."
 
 #: _verbose
-msgid "exec_as_user '::1 user::': ::2::"
-msgstr "exec_as_user '::1 usuario::': ::2::"
-
-#: _verbose
 msgid "Using sudo for root execution of '::1 exec:: ::2 args::'."
-msgstr "Usando sudo para la ejecución como root de '::1 comando:: ::2 argumentos::'."
+msgstr ""
+"Usando sudo para la ejecución como root de '::1 comando:: ::2 argumentos::'."
 
 #: _verbose
 msgid "Escalating privileges using sudo-pwd."
 msgstr "Escalando privilegios usando sudo-pwd."
-
-#: _verbose
-msgid "is_valid_tomb ::1 tomb file::"
-msgstr "is_valid_tomb ::1 tumba::"
 
 #: _warning
 msgid "Tomb file is missing from arguments."
@@ -99,28 +91,12 @@ msgid "lo_preserve on ::1 path::"
 msgstr "lo_preserve en ::1 ruta::"
 
 #: _verbose
-msgid "tomb_file: ::1 tomb file::"
-msgstr "tomb_file ::1 tumba::"
-
-#: _verbose
 msgid "tomb_key: ::1 key:: chars long"
 msgstr "tomb_key: ::1:: carácteres de largo"
 
 #: _verbose
-msgid "tomb_key_file: ::1 key::"
-msgstr "tomb_key_file: ::1 llave::"
-
-#: _verbose
 msgid "tomb_secret: ::1 secret:: chars long"
 msgstr "tomb_secret: ::1:: carácteres de largo"
-
-#: _verbose
-msgid "tomb_password: ::1 tomb pass::"
-msgstr "tomb_password: ::1 contraseña::"
-
-#: _verbose
-msgid "tomb_tempfiles: ::1 temp files::"
-msgstr "tomb_tempfiles: ::1 ficheros::"
 
 #: _print
 msgid "Syntax: tomb [options] command [arguments]"
@@ -211,8 +187,7 @@ msgstr "Opciones:"
 
 #: _print
 msgid " -s     size of the tomb file when creating/resizing one (in MB)"
-msgstr ""
-" -s     tamaño de la tumba al crearla o cambiar su tamaño (en MB)"
+msgstr " -s     tamaño de la tumba al crearla o cambiar su tamaño (en MB)"
 
 #: _print
 msgid " -k     path to the key to be used ('-k -' to read from stdin)"
@@ -262,7 +237,9 @@ msgstr "Por favor, reporta los bugs en <http://github.com/dyne/tomb/issues>."
 
 #: _failure
 msgid "Cannot find ::1::. It's a requirement to use Tomb, please install it."
-msgstr "No se pudo encontrar ::1::. Es necesario para usar Tomb, por favor, instálalo."
+msgstr ""
+"No se pudo encontrar ::1::. Es necesario para usar Tomb, por favor, "
+"instálalo."
 
 #: _warning
 msgid "is_valid_key() called without argument."
@@ -282,8 +259,7 @@ msgstr "Intentando recuperar la llave."
 
 #: _failure
 msgid "This operation requires a key file to be specified using the -k option."
-msgstr ""
-"Esta operación requiere que se especifique una llave con la opción -k."
+msgstr "Esta operación requiere que se especifique una llave con la opción -k."
 
 #: _verbose
 msgid "load_key reading from stdin."
@@ -302,8 +278,11 @@ msgid "Key not found, specify one using -k."
 msgstr "Llave no encontrada, especifica una usando -k."
 
 #: _warning
-msgid "The key seems invalid or its format is not known by this version of Tomb."
-msgstr "La llave parece inválida, o este formato no es reconocido por esta versión de Tomb."
+msgid ""
+"The key seems invalid or its format is not known by this version of Tomb."
+msgstr ""
+"La llave parece inválida, o este formato no es reconocido por esta versión "
+"de Tomb."
 
 #: _verbose
 msgid "GnuPG is version 1.4.11 - adopting status fix."
@@ -370,7 +349,8 @@ msgid "gen_key takes tombpass from CLI argument: ::1 tomb pass::"
 msgstr ""
 
 #: _failure
-msgid "Wrong argument for --kdf: must be an integer number (iteration seconds)."
+msgid ""
+"Wrong argument for --kdf: must be an integer number (iteration seconds)."
 msgstr ""
 "Argumento incorrecto para --kdf: debe ser un número entero (segundos por "
 "iteración)."
@@ -594,8 +574,10 @@ msgid "Data dump using ::1:: from /dev/urandom"
 msgstr "Volcado de datos usando ::1:: de /dev/urandom"
 
 #: _failure
-msgid "Error creating the tomb ::1 tomb dir::/::2 tomb file::, operation aborted."
-msgstr "Error al crear la tumba ::1 directorio::/::2 fichero::, operación abortada."
+msgid ""
+"Error creating the tomb ::1 tomb dir::/::2 tomb file::, operation aborted."
+msgstr ""
+"Error al crear la tumba ::1 directorio::/::2 fichero::, operación abortada."
 
 #: _success
 msgid "Done digging ::1 tomb name::"
@@ -603,7 +585,8 @@ msgstr "He terminado de cavar ::1 tumba::"
 
 #: _message
 msgid "Your tomb is not yet ready, you need to forge a key and lock it:"
-msgstr "Tu tumba no está lista todavía, tienes que forjar una llave y asegurarla:"
+msgstr ""
+"Tu tumba no está lista todavía, tienes que forjar una llave y asegurarla:"
 
 #: _warning
 msgid "No tomb specified for locking."
@@ -704,7 +687,8 @@ msgstr "Se ha ordenado resetear la llave para la tumba ::1 tumba::"
 
 #: _warning
 msgid "Command 'setkey' needs two arguments: the old key file and the tomb."
-msgstr "El comando 'setkey' necesita dos argumentos: la vieja llave y la tumba."
+msgstr ""
+"El comando 'setkey' necesita dos argumentos: la vieja llave y la tumba."
 
 #: _warning
 msgid "I.e:  tomb -k new.tomb.key old.tomb.key secret.tomb"
@@ -720,7 +704,8 @@ msgstr "No es un volumen LUKS encriptado válido: ::1 volumen::"
 
 #: _failure
 msgid "Aborting operations: error loading old key from arguments"
-msgstr "Abortando operaciones: error al cargar la vieja llave de los argumentos"
+msgstr ""
+"Abortando operaciones: error al cargar la vieja llave de los argumentos"
 
 #: _success
 msgid "Changing lock on tomb ::1 tomb name::"
@@ -830,8 +815,11 @@ msgstr ""
 "El cifrado es \"::1 cifrado::\" en modo \"::2 modo::\" y hash \"::3 hash::\""
 
 #: _warning
-msgid "Multiple key slots are enabled on this tomb. Beware: there can be a backdoor."
-msgstr "Hay múltiples rarunas para la llave en esta tumba. Cuidado: puede haber una puerta trasera."
+msgid ""
+"Multiple key slots are enabled on this tomb. Beware: there can be a backdoor."
+msgstr ""
+"Hay múltiples rarunas para la llave en esta tumba. Cuidado: puede haber una "
+"puerta trasera."
 
 #: _verbose
 msgid "dev mapper device: ::1 mapper::"
@@ -871,7 +859,9 @@ msgstr "::1 tumba:: ha sido abierta en ::2 punto de montaje::"
 
 #: _message
 msgid "Last visit by ::1 user::(::2 tomb build::) from ::3 tty:: on ::4 host::"
-msgstr "Última visita de ::1 usuario::(::2 versión de tomb::) desde ::3 tty:: en ::4 host::"
+msgstr ""
+"Última visita de ::1 usuario::(::2 versión de tomb::) desde ::3 tty:: en ::4 "
+"host::"
 
 #: _message
 msgid "on date ::1 date::"
@@ -895,15 +885,21 @@ msgstr "Formato de mapeo de los bind-hooks: local/to/tomb local/to/$HOME"
 
 #: _warning
 msgid "bind-hooks map format: local/to/tomb local/to/$HOME.  Rolling back"
-msgstr "Formato de mapeo de los bind-hooks: local/to/tomb local/to/HOME. Restaurando"
+msgstr ""
+"Formato de mapeo de los bind-hooks: local/to/tomb local/to/HOME. Restaurando"
 
 #: _warning
 msgid "bind-hook target not existent, skipping ::1 home::/::2 subdir::"
-msgstr "No existe un objetivo para el bind-hook, omitiendo ::1 hogar::/::2 directorio::"
+msgstr ""
+"No existe un objetivo para el bind-hook, omitiendo ::1 hogar::/::2 "
+"directorio::"
 
 #: _warning
-msgid "bind-hook source not found in tomb, skipping ::1 mount point::/::2 subdir::"
-msgstr "No se ha encontrado la fuente para el bind-hook en la tumba, omitiendo ::1 punto de montaje::/::2 directorio::"
+msgid ""
+"bind-hook source not found in tomb, skipping ::1 mount point::/::2 subdir::"
+msgstr ""
+"No se ha encontrado la fuente para el bind-hook en la tumba, omitiendo ::1 "
+"punto de montaje::/::2 directorio::"
 
 #: _success
 msgid "Post hooks found, executing as user ::1 user name::."
@@ -919,7 +915,9 @@ msgstr "Error interno: se ha llamado a list_tomb_binds sin argumento."
 
 #: _failure
 msgid "Cannot index tombs on this system: updatedb (mlocate) not installed."
-msgstr "No se pueden indexar la tumbas en este sistema: updatedb (mlocate) no está instalado."
+msgstr ""
+"No se pueden indexar la tumbas en este sistema: updatedb (mlocate) no está "
+"instalado."
 
 #: _warning
 msgid "Cannot use GNU findutils for index/search commands."
@@ -928,10 +926,6 @@ msgstr "No se puede usar GNU findutils para los comandos index/search."
 #: _failure
 msgid "Index command needs 'mlocate' to be installed."
 msgstr "El comando index necesita que 'mlocate' esté instalado."
-
-#: _verbose
-msgid "$updatedbver"
-msgstr ""
 
 #: _failure
 msgid "There seems to be no open tomb engraved as [::1::]"
@@ -1003,11 +997,14 @@ msgstr "Búsqueda completada."
 
 #: _message
 msgid "Commanded to resize tomb ::1 tomb name:: to ::2 size:: megabytes."
-msgstr "Se ha ordenado cambiar el tamaño de la tumba ::1 tumba:: a ::2 tamaño:: megabytes."
+msgstr ""
+"Se ha ordenado cambiar el tamaño de la tumba ::1 tumba:: a ::2 tamaño:: "
+"megabytes."
 
 #: _failure
 msgid "No tomb name specified for resizing."
-msgstr "No se ha especificado el nombre de la tumba a la que cambiar el tamaño."
+msgstr ""
+"No se ha especificado el nombre de la tumba a la que cambiar el tamaño."
 
 #: _failure
 msgid "Cannot find ::1::"
@@ -1089,7 +1086,8 @@ msgstr "Por favor, especifica una tumba existente."
 
 #: _success
 msgid "Slamming tomb ::1 tomb name:: mounted on ::2 mount point::"
-msgstr "Cerrando de un portazo la tumba ::1 tumba:: montada en ::2 punto de montaje::"
+msgstr ""
+"Cerrando de un portazo la tumba ::1 tumba:: montada en ::2 punto de montaje::"
 
 #: _message
 msgid "Kill all processes busy inside the tomb."
@@ -1109,7 +1107,8 @@ msgstr "Cerrando el bind-hook: ::1::"
 
 #: _success
 msgid "Slamming tomb: killing all processes using this hook."
-msgstr "Cerrando tumba de un portazo: matando todos los procesos que usan este hook."
+msgstr ""
+"Cerrando tumba de un portazo: matando todos los procesos que usan este hook."
 
 #: _warning
 msgid "Cannot slam the bind hook ::1 hook::"
@@ -1161,12 +1160,18 @@ msgstr "Véase \"tomb help\" par más información."
 
 #: _failure
 msgid "Unrecognized option ::1 arg:: for subcommand ::2 subcommand::"
-msgstr "No se reconoce la opción ::1 argumento:: para el subcomando ::2 subcomando::"
+msgstr ""
+"No se reconoce la opción ::1 argumento:: para el subcomando ::2 subcomando::"
 
 #: _failure
-msgid "You specified option ::1 option::, which is DANGEROUS and should only be used for testing\n"
+msgid ""
+"You specified option ::1 option::, which is DANGEROUS and should only be "
+"used for testing\n"
 "If you really want so, add --unsecure-dev-mode"
-msgstr "Has especificado la opción ::1 opción::, que es PELIGROSA y sólo se debería usar para el testeo\nSi realmente quieres usarla, añade --unsecure-dev-mode"
+msgstr ""
+"Has especificado la opción ::1 opción::, que es PELIGROSA y sólo se debería "
+"usar para el testeo\n"
+"Si realmente quieres usarla, añade --unsecure-dev-mode"
 
 #: _verbose
 msgid "Tomb command: ::1 subcommand:: ::2 param::"
@@ -1181,8 +1186,11 @@ msgid "QREncode not installed: cannot engrave keys on paper."
 msgstr "QREncode no está instalado: no se pueden grabar las llave en papel."
 
 #: _warning
-msgid "The create command is deprecated, please use dig, forge and lock instead."
-msgstr "El comando create está obsoleto, por favor, usa dig, forge y lock en su lugar."
+msgid ""
+"The create command is deprecated, please use dig, forge and lock instead."
+msgstr ""
+"El comando create está obsoleto, por favor, usa dig, forge y lock en su "
+"lugar."
 
 #: _warning
 msgid "For more informations see Tomb's manual page (man tomb)."
@@ -1190,15 +1198,18 @@ msgstr "Para más información mira el manual de Tomb (man tomb)."
 
 #: _failure
 msgid "Steghide not installed: cannot bury keys into images."
-msgstr "Steghide no está instalado: no se pueden enterrar llaves en las imágenes."
+msgstr ""
+"Steghide no está instalado: no se pueden enterrar llaves en las imágenes."
 
 #: _failure
 msgid "Steghide not installed: cannot exhume keys from images."
-msgstr "Setghide no está instalado: no se pueden exhumar llaves de las imágenes."
+msgstr ""
+"Setghide no está instalado: no se pueden exhumar llaves de las imágenes."
 
 #: _failure
 msgid "Resize2fs not installed: cannot resize tombs."
-msgstr "Resize2fs no está instalado: no se puede cambiar el tamaño de las tumbas."
+msgstr ""
+"Resize2fs no está instalado: no se puede cambiar el tamaño de las tumbas."
 
 #: _print
 msgid "Tomb ::1 version:: - a strong and gentle undertaker for your secrets"

--- a/extras/po/fr.po
+++ b/extras/po/fr.po
@@ -21,21 +21,12 @@ msgid "Operation aborted."
 msgstr "L'opération est interrompue."
 
 #: _verbose
-msgid "exec_as_user '::1 user::': ::2::"
-msgstr ""
-
-#: _verbose
 msgid "Using sudo for root execution of '::1 exec:: ::2 args::'."
 msgstr ""
 
 #: _verbose
 msgid "Escalating privileges using sudo-pwd."
 msgstr ""
-
-#: _verbose
-#, fuzzy
-msgid "is_valid_tomb ::1 tomb file::"
-msgstr "Le fichier valide d'une tombe a été trouvé : ::1 tomb file::"
 
 #: _warning
 msgid "Tomb file is missing from arguments."
@@ -103,35 +94,11 @@ msgid "lo_preserve on ::1 path::"
 msgstr ""
 
 #: _verbose
-#, fuzzy
-msgid "tomb_file: ::1 tomb file::"
-msgstr "Le fichier valide d'une tombe a été trouvé : ::1 tomb file::"
-
-#: _verbose
 msgid "tomb_key: ::1 key:: chars long"
 msgstr ""
 
 #: _verbose
-#, fuzzy
-msgid "tomb_key_file: ::1 key::"
-msgstr "Clé précédente : ::1 key::"
-
-#: _verbose
 msgid "tomb_secret: ::1 secret:: chars long"
-msgstr ""
-
-#: _verbose
-#, fuzzy
-msgid "tomb_password: ::1 tomb pass::"
-msgstr "Tombe introuvable : ::1 tomb name::"
-
-#: _verbose
-#, fuzzy
-msgid "tomb_tempfiles: ::1 temp files::"
-msgstr "Le fichier valide d'une tombe a été trouvé : ::1 tomb file::"
-
-#: _verbose
-msgid "tomb_loopdevs: ::1 loopdevs::"
 msgstr ""
 
 #: _print
@@ -297,10 +264,6 @@ msgstr ""
 msgid "Cannot find ::1::. It's a requirement to use Tomb, please install it."
 msgstr ""
 
-#: _verbose
-msgid "is_valid_key"
-msgstr ""
-
 #: _warning
 msgid "is_valid_key() called without argument."
 msgstr ""
@@ -339,11 +302,6 @@ msgstr ""
 msgid "Key not found, specify one using -k."
 msgstr "Aucune clé n'a été trouvée, merci d'en spécifier une avec -k."
 
-#: _verbose
-#, fuzzy
-msgid "load_key: ::1 key::"
-msgstr "Clé précédente : ::1 key::"
-
 #: _warning
 msgid ""
 "The key seems invalid or its format is not known by this version of Tomb."
@@ -351,14 +309,6 @@ msgstr ""
 
 #: _verbose
 msgid "GnuPG is version 1.4.11 - adopting status fix."
-msgstr ""
-
-#: _verbose
-msgid "get_lukskey"
-msgstr ""
-
-#: _verbose
-msgid "KDF: ::1 kdf::"
 msgstr ""
 
 #: _failure
@@ -400,18 +350,10 @@ msgstr ""
 msgid "Changing password for ::1 key file::"
 msgstr "Mise à jour du mot de passe de ::1 key::."
 
-#: _verbose
-msgid "tomb-old-pwd = ::1 old pass::"
-msgstr ""
-
 #: _failure
 #, fuzzy
 msgid "No valid password supplied."
 msgstr "Le mot de passe fourni est invalide."
-
-#: _verbose
-msgid "tomb-pwd = ::1 new pass::"
-msgstr ""
 
 #: _failure
 msgid "Error: the newly generated keyfile does not seem valid."
@@ -479,11 +421,6 @@ msgstr "Inscription de la clé ::1 key:: dans l'image ::2 image file::"
 #: _message
 msgid "Please confirm the key password for the encoding"
 msgstr "Merci de confirmer le mot de passe de la clé en vue de l'encodage"
-
-#: _verbose
-#, fuzzy
-msgid "tomb-pwd = ::1 tomb pass::"
-msgstr "Fermons la tombe ::1 tomb name::"
 
 #: _warning
 msgid "Wrong password supplied."
@@ -579,10 +516,6 @@ msgstr "Forge de la clé ::1 key::"
 msgid "Forging this key would overwrite an existing file. Operation aborted."
 msgstr "Forger cette clé détruirait un fichier existant.  Opération annulée."
 
-#: _failure
-msgid "`ls -lh $destkey`"
-msgstr ""
-
 #: _message
 msgid "Commanded to forge key ::1 key:: with cipher algorithm ::2 algorithm::"
 msgstr ""
@@ -636,10 +569,6 @@ msgstr "La clé semble être invalide."
 msgid "Dumping contents to screen:"
 msgstr "Capture des contenus à l'écran :"
 
-#: _warning
-msgid "--"
-msgstr "--"
-
 #: _message
 msgid "Done forging ::1 key::"
 msgstr "La clé ::1 key:: a été forgée"
@@ -673,10 +602,6 @@ msgstr "La taille minimale d'une tombe est de 10 megaoctets."
 msgid "A tomb exists already. I'm not digging here:"
 msgstr "Une tombe existe déjà à cet endroit. Je n'y creuse pas !"
 
-#: _warning
-msgid " `ls -lh ${tombdir}/${tombfile}`"
-msgstr ""
-
 #: _success
 #, fuzzy
 msgid "Creating a new tomb in ::1 tomb dir::/::2 tomb file::"
@@ -707,14 +632,6 @@ msgid "Your tomb is not yet ready, you need to forge a key and lock it:"
 msgstr ""
 "Votre tombe n'est pas encore prête, vous devez en forger la clé et la "
 "vérouiller :"
-
-#: _message
-msgid "tomb forge ::1 tomb name::.tomb.key"
-msgstr "tomb forge ::1 tomb name::.tomb.key"
-
-#: _message
-msgid "tomb lock ::1 tomb name::.tomb -k ::1 tomb name::.tomb.key"
-msgstr "tomb lock ::1 tomb name::.tomb -k ::1 tomb name::.tomb.key"
 
 #: _warning
 msgid "No tomb specified for locking."
@@ -887,10 +804,6 @@ msgstr "Le verrou est changé sur la tombe ::1 tomb file::"
 #, fuzzy
 msgid "The new key is: ::1 new key::"
 msgstr "La nouvelle clé est : ::1 key::"
-
-#: _verbose
-msgid "create_tomb(): ::1:: ::2::"
-msgstr ""
 
 #: _warning
 #, fuzzy
@@ -1085,10 +998,6 @@ msgstr ""
 
 #: _failure
 msgid "Index command needs 'mlocate' to be installed."
-msgstr ""
-
-#: _verbose
-msgid "$updatedbver"
 msgstr ""
 
 #: _failure

--- a/extras/po/ru.po
+++ b/extras/po/ru.po
@@ -21,21 +21,12 @@ msgid "Operation aborted."
 msgstr "Операция отменена."
 
 #: _verbose
-msgid "exec_as_user '::1 user::': ::2::"
-msgstr ""
-
-#: _verbose
 msgid "Using sudo for root execution of '::1 exec:: ::2 args::'."
 msgstr ""
 
 #: _verbose
 msgid "Escalating privileges using sudo-pwd."
 msgstr ""
-
-#: _verbose
-#, fuzzy
-msgid "is_valid_tomb ::1 tomb file::"
-msgstr "Найден верный файл гробницы: ::1 tomb file::"
 
 #: _warning
 msgid "Tomb file is missing from arguments."
@@ -97,35 +88,11 @@ msgid "lo_preserve on ::1 path::"
 msgstr ""
 
 #: _verbose
-#, fuzzy
-msgid "tomb_file: ::1 tomb file::"
-msgstr "Найден верный файл гробницы: ::1 tomb file::"
-
-#: _verbose
 msgid "tomb_key: ::1 key:: chars long"
 msgstr ""
 
 #: _verbose
-#, fuzzy
-msgid "tomb_key_file: ::1 key::"
-msgstr "Старый ключ: ::1 key::"
-
-#: _verbose
 msgid "tomb_secret: ::1 secret:: chars long"
-msgstr ""
-
-#: _verbose
-#, fuzzy
-msgid "tomb_password: ::1 tomb pass::"
-msgstr "Гробница не найдена: ::1 tomb name::"
-
-#: _verbose
-#, fuzzy
-msgid "tomb_tempfiles: ::1 temp files::"
-msgstr "Найден верный файл гробницы: ::1 tomb file::"
-
-#: _verbose
-msgid "tomb_loopdevs: ::1 loopdevs::"
 msgstr ""
 
 #: _print
@@ -269,10 +236,6 @@ msgstr ""
 msgid "Cannot find ::1::. It's a requirement to use Tomb, please install it."
 msgstr ""
 
-#: _verbose
-msgid "is_valid_key"
-msgstr ""
-
 #: _warning
 msgid "is_valid_key() called without argument."
 msgstr ""
@@ -309,11 +272,6 @@ msgstr ""
 msgid "Key not found, specify one using -k."
 msgstr "Ключ не найден, укажите его с помощью опции -k."
 
-#: _verbose
-#, fuzzy
-msgid "load_key: ::1 key::"
-msgstr "Старый ключ: ::1 key::"
-
 #: _warning
 msgid ""
 "The key seems invalid or its format is not known by this version of Tomb."
@@ -321,14 +279,6 @@ msgstr ""
 
 #: _verbose
 msgid "GnuPG is version 1.4.11 - adopting status fix."
-msgstr ""
-
-#: _verbose
-msgid "get_lukskey"
-msgstr ""
-
-#: _verbose
-msgid "KDF: ::1 kdf::"
 msgstr ""
 
 #: _failure
@@ -369,18 +319,10 @@ msgstr "Приказано изменить пароль для ключа ::1 k
 msgid "Changing password for ::1 key file::"
 msgstr "Меняю пароль для ::1 key::"
 
-#: _verbose
-msgid "tomb-old-pwd = ::1 old pass::"
-msgstr ""
-
 #: _failure
 #, fuzzy
 msgid "No valid password supplied."
 msgstr "Указан неверный пароль."
-
-#: _verbose
-msgid "tomb-pwd = ::1 new pass::"
-msgstr ""
 
 #: _failure
 msgid "Error: the newly generated keyfile does not seem valid."
@@ -446,11 +388,6 @@ msgstr "Шифрую ключ ::1 key:: в изображение ::2 image file
 #: _message
 msgid "Please confirm the key password for the encoding"
 msgstr "Пожалуйста, подтвердите пароль ключа для шифрования"
-
-#: _verbose
-#, fuzzy
-msgid "tomb-pwd = ::1 tomb pass::"
-msgstr "Закрываю гробницу ::1 tomb name::"
 
 #: _warning
 msgid "Wrong password supplied."
@@ -545,10 +482,6 @@ msgstr "Приказано выковать ключ ::1 key::"
 msgid "Forging this key would overwrite an existing file. Operation aborted."
 msgstr "Выковка этого ключа перезапишет существующий файл. Операция отменена."
 
-#: _failure
-msgid "`ls -lh $destkey`"
-msgstr ""
-
 #: _message
 msgid "Commanded to forge key ::1 key:: with cipher algorithm ::2 algorithm::"
 msgstr ""
@@ -595,10 +528,6 @@ msgstr "Ключ неверен."
 msgid "Dumping contents to screen:"
 msgstr "Выгрузка содержимого на экран:"
 
-#: _warning
-msgid "--"
-msgstr "--"
-
 #: _message
 msgid "Done forging ::1 key::"
 msgstr "Ключ выкован: ::1 key::"
@@ -632,10 +561,6 @@ msgstr "Гробницы не могут быть меньше 10 Мб."
 msgid "A tomb exists already. I'm not digging here:"
 msgstr "Гробница существует. Я не буду копать здесь:"
 
-#: _warning
-msgid " `ls -lh ${tombdir}/${tombfile}`"
-msgstr ""
-
 #: _success
 #, fuzzy
 msgid "Creating a new tomb in ::1 tomb dir::/::2 tomb file::"
@@ -662,14 +587,6 @@ msgstr "Выкопана гробница ::1 tomb name::"
 #: _message
 msgid "Your tomb is not yet ready, you need to forge a key and lock it:"
 msgstr "Ваша гробница пока не готова, необходимо выковать ключ и запереть ее:"
-
-#: _message
-msgid "tomb forge ::1 tomb name::.tomb.key"
-msgstr "tomb forge ::1 tomb name::.tomb.key"
-
-#: _message
-msgid "tomb lock ::1 tomb name::.tomb -k ::1 tomb name::.tomb.key"
-msgstr "tomb lock ::1 tomb name::.tomb -k ::1 tomb name::.tomb.key"
 
 #: _warning
 msgid "No tomb specified for locking."
@@ -839,10 +756,6 @@ msgstr "Смена ключа успешна для гробницы: ::1 tomb f
 #, fuzzy
 msgid "The new key is: ::1 new key::"
 msgstr "Новый ключ: ::1 key::"
-
-#: _verbose
-msgid "create_tomb(): ::1:: ::2::"
-msgstr ""
 
 #: _warning
 #, fuzzy
@@ -1026,10 +939,6 @@ msgstr ""
 
 #: _failure
 msgid "Index command needs 'mlocate' to be installed."
-msgstr ""
-
-#: _verbose
-msgid "$updatedbver"
 msgstr ""
 
 #: _failure

--- a/extras/po/tomb.pot
+++ b/extras/po/tomb.pot
@@ -27,19 +27,11 @@ msgid "Operation aborted."
 msgstr ""
 
 #: _verbose
-msgid "exec_as_user '::1 user::': ::2::"
-msgstr ""
-
-#: _verbose
 msgid "Using sudo for root execution of '::1 exec:: ::2 args::'."
 msgstr ""
 
 #: _verbose
 msgid "Escalating privileges using sudo-pwd."
-msgstr ""
-
-#: _verbose
-msgid "is_valid_tomb ::1 tomb file::"
 msgstr ""
 
 #: _warning
@@ -95,31 +87,11 @@ msgid "lo_preserve on ::1 path::"
 msgstr ""
 
 #: _verbose
-msgid "tomb_file: ::1 tomb file::"
-msgstr ""
-
-#: _verbose
 msgid "tomb_key: ::1 key:: chars long"
 msgstr ""
 
 #: _verbose
-msgid "tomb_key_file: ::1 key::"
-msgstr ""
-
-#: _verbose
 msgid "tomb_secret: ::1 secret:: chars long"
-msgstr ""
-
-#: _verbose
-msgid "tomb_password: ::1 tomb pass::"
-msgstr ""
-
-#: _verbose
-msgid "tomb_tempfiles: ::1 temp files::"
-msgstr ""
-
-#: _verbose
-msgid "tomb_loopdevs: ::1 loopdevs::"
 msgstr ""
 
 #: _print
@@ -258,10 +230,6 @@ msgstr ""
 msgid "Cannot find ::1::. It's a requirement to use Tomb, please install it."
 msgstr ""
 
-#: _verbose
-msgid "is_valid_key"
-msgstr ""
-
 #: _warning
 msgid "is_valid_key() called without argument."
 msgstr ""
@@ -298,24 +266,12 @@ msgstr ""
 msgid "Key not found, specify one using -k."
 msgstr ""
 
-#: _verbose
-msgid "load_key: ::1 key::"
-msgstr ""
-
 #: _warning
 msgid "The key seems invalid or its format is not known by this version of Tomb."
 msgstr ""
 
 #: _verbose
 msgid "GnuPG is version 1.4.11 - adopting status fix."
-msgstr ""
-
-#: _verbose
-msgid "get_lukskey"
-msgstr ""
-
-#: _verbose
-msgid "KDF: ::1 kdf::"
 msgstr ""
 
 #: _failure
@@ -354,16 +310,8 @@ msgstr ""
 msgid "Changing password for ::1 key file::"
 msgstr ""
 
-#: _verbose
-msgid "tomb-old-pwd = ::1 old pass::"
-msgstr ""
-
 #: _failure
 msgid "No valid password supplied."
-msgstr ""
-
-#: _verbose
-msgid "tomb-pwd = ::1 new pass::"
 msgstr ""
 
 #: _failure
@@ -424,10 +372,6 @@ msgstr ""
 
 #: _message
 msgid "Please confirm the key password for the encoding"
-msgstr ""
-
-#: _verbose
-msgid "tomb-pwd = ::1 tomb pass::"
 msgstr ""
 
 #: _warning
@@ -517,10 +461,6 @@ msgstr ""
 msgid "Forging this key would overwrite an existing file. Operation aborted."
 msgstr ""
 
-#: _failure
-msgid "`ls -lh $destkey`"
-msgstr ""
-
 #: _message
 msgid "Commanded to forge key ::1 key:: with cipher algorithm ::2 algorithm::"
 msgstr ""
@@ -565,10 +505,6 @@ msgstr ""
 msgid "Dumping contents to screen:"
 msgstr ""
 
-#: _warning
-msgid "--"
-msgstr ""
-
 #: _message
 msgid "Done forging ::1 key::"
 msgstr ""
@@ -601,10 +537,6 @@ msgstr ""
 msgid "A tomb exists already. I'm not digging here:"
 msgstr ""
 
-#: _warning
-msgid " `ls -lh ${tombdir}/${tombfile}`"
-msgstr ""
-
 #: _success
 msgid "Creating a new tomb in ::1 tomb dir::/::2 tomb file::"
 msgstr ""
@@ -627,14 +559,6 @@ msgstr ""
 
 #: _message
 msgid "Your tomb is not yet ready, you need to forge a key and lock it:"
-msgstr ""
-
-#: _message
-msgid "tomb forge ::1 tomb name::.tomb.key"
-msgstr ""
-
-#: _message
-msgid "tomb lock ::1 tomb name::.tomb -k ::1 tomb name::.tomb.key"
 msgstr ""
 
 #: _warning
@@ -787,10 +711,6 @@ msgstr ""
 
 #: _message
 msgid "The new key is: ::1 new key::"
-msgstr ""
-
-#: _verbose
-msgid "create_tomb(): ::1:: ::2::"
 msgstr ""
 
 #: _warning
@@ -951,10 +871,6 @@ msgstr ""
 
 #: _failure
 msgid "Index command needs 'mlocate' to be installed."
-msgstr ""
-
-#: _verbose
-msgid "$updatedbver"
 msgstr ""
 
 #: _failure


### PR DESCRIPTION
This PR updates the spanish translations and removes some strings that don't need to be translated (`tomb-pass: ::1 tomb pass::`) from the template and po files.
