### PR TITLE
Remove outdated error message

### DIFF
--- a/tomb
+++ b/tomb
@@ -271,9 +271,6 @@ _tmp_create() {
     [[ $? == 0 ]] || {
         _failure "Fatal error creating a temporary file: ::1 temp file::" "$tfile" }
 
-    [[ $? == 0 ]] || {
-        _failure "Fatal error setting ownership on temporary file: ::1 temp file::" "$tfile" }
-
     _verbose "Created tempfile: ::1 temp file::" "$tfile"
     TOMBTMP="$tfile"
     TOMBTMPFILES+=("$tfile")


### PR DESCRIPTION
Commit 5dbcabdf2636300f6877e6bab27ef51c7b739a8f removed the `chown` call in `_tmp_create()` but not the associated error message. This commit removes that error message since it is just dead code.