### PR TITLE
FIX errors on kdf iteration count

### DIFF
--- a/doc/tomb.1
+++ b/doc/tomb.1
@@ -193,10 +193,12 @@ what you are doing if you force an operation.
 When digging or resizing a tomb, this option must be used to specify
 the \fIsize\fR of the new file to be created. Units are megabytes (MiB).
 .B
-.IP "--kdf \fI<iterations>\fR"
+.IP "--kdf \fI<itertime>\fR"
 Activate the KDF feature against dictionary attacks when creating a
-key: forces a delay of \fI<iterations>\fR (integer multiplied by 10k)
-every time this key is used.
+key: forces a delay of \fI<itertime>\fR seconds every time this key is used.
+You should keep in mind that the actual iteration count is calculated based on
+the performance of the computer where you forge the key.
+The argument must be an integer, so you cannot say \fI--kdf 0.3\fR for 300ms.
 .B
 .IP "-h"
 Display a help text and quit.

--- a/tomb
+++ b/tomb
@@ -1138,8 +1138,8 @@ gen_key() {
             fi
             # --kdf takes one parameter: iter time (on present machine) in seconds
             local -i microseconds
-            microseconds=$(( itertime * 10000 ))
-            _success "Using KDF, iterations: ::1 microseconds::" $microseconds
+            microseconds=$(( itertime * 1000000 ))
+            _success "Using KDF, iteration time: ::1 microseconds::" $microseconds
             _message "generating salt"
             pbkdf2_salt=`tomb-kdb-pbkdf2-gensalt`
             _message "calculating iterations"


### PR DESCRIPTION
Both the code and the documentation were incorrect about --kdf.

The code was using an iteration time much inferior to the one that the user could be expecting. The output messages were even more confusing, calling "count" what was actually "time".

The same error was present in the man page.

This commit tries to fix both of them.

This will close #192
