### PR TITLE
Two minor one-line fixes

### DIFF
--- a/tomb
+++ b/tomb
@@ -950,7 +950,6 @@ get_lukskey() {
 
     _password="$1"
 
-    exhumedkey=""
 
     firstline="${TOMBKEY[(f)1]}"
 

--- a/tomb
+++ b/tomb
@@ -1036,7 +1036,6 @@ ask_key_password() {
         }
 
     fi
-    # print the password out in case caller needs to know it
     [[ $passok == 1 ]] || return 1
 
     TOMBPASSWORD=$tombpass


### PR DESCRIPTION
The `exhumedkey` variable is initialized but never used, so this PR removes it. The comment removed by this PR is inaccurate. (The following line does not print the password.)