### PR TITLE
Fixed broken images in Tomb_User_Manual.org

### DIFF
--- a/doc/Tomb_User_Manual.org
+++ b/doc/Tomb_User_Manual.org
@@ -72,7 +72,7 @@ resistance to omologation.
 
 ** Who needs Tomb
 
-[[file:tomb_and_bats.png]]
+[[file:https://github.com/dyne/Tomb/blob/master/extras/images/tomb_and_bats.png]]
 
 Tomb improves the usability patterns of every-day cryptography and
 relies on military-grade algorithms to grant a level of secrecy for
@@ -127,8 +127,6 @@ Tomb is an evolution of the /Nesting/ tool developed in 2001 for the
 Home directory of users and have it ready for use on different
 machines. At that time, Tomb was the first secure implementation of
 what nowadays we call /persistent storage/ in live operating systems.
-
-[[file:foster_privacy.png]]
 
 Later on we've felt the urgency to publishing this mechanism for other
 operating systems than dyne:bolic since the current situation in


### PR DESCRIPTION
There's two images in Tomb_User_Manual.org that were broken. The first
one was tomb_and_bats.png and the second was foster_privacy.png.

Image tomb_and_bats.png was relinked. The link to foster_privacy.png was
removed because I couldn't find the image in the repository.