### PR TITLE
extras: fix tomber repository URL

### DIFF
--- a/extras/PYTHON.md
+++ b/extras/PYTHON.md
@@ -15,7 +15,7 @@ functionalities in other languages.
 
 Tomber is still under development. Any contributions are greatly
 welcomed here or on its original repository
-https://github.com/reiven/Tomb
+https://github.com/reiven/tomber
 
 
 Installation


### PR DESCRIPTION
I noticed this small error, while I skimmed through the extras folder.

On another note. The tomber lib is out of sync with upstream (dunno what version was integrated with this repo (I assume 1.0.1)), but upstream is at 1.0.2 now.
Wouldn't it be easier to integrate tomber as a submodule?

Edit: Or as a subtree (maybe it's done like that. But it's hard to tell from the outside or is there a method to check for those?)