### PR TITLE
Changed message when encrypted swap found to something more informative

### DIFF
--- a/tomb
+++ b/tomb
@@ -325,7 +325,7 @@ _ensure_safe_swap() {
     done
 
     if [[ $r -eq 2 ]]; then
-        _success "All your swaps are belong to crypt. Good."
+        _success "The undertaker found that all swap partitions are encrypted. Good."
     else
         _warning "This poses a security risk."
         _warning "You can deactivate all swap partitions using the command:"


### PR DESCRIPTION
In relation to #229, I found the current message to be a bit ambiguous. When I first started using Tomb, I wasn't sure if the success message was a good one or a bad one. Hopefully a clearer message will let new users understand that their swap is encrypted.