### PR TITLE
Open non-writable Tomb files with "read only " mount option

### DIFF
--- a/extras/test/runtests
+++ b/extras/test/runtests
@@ -56,7 +56,7 @@ command -v qrencode > /dev/null || QRENCODE=0
 
 
 typeset -A results
-tests=(dig forge lock badpass open close passwd chksum bind setkey)
+tests=(dig forge lock badpass open close openro passwd chksum bind setkey)
 { test $RESIZER = 1 } && { tests+=(resize) }
 { test $KDF = 1 } && { tests+=(kdforge kdfpass kdflock kdfopen) }
 { test $STEGHIDE = 1 } && { tests+=(stgin stgout stgopen stgpipe stgimpl) }
@@ -194,7 +194,32 @@ test-regression() {
 }
 
 
+test-open-read-only() {
 
+    notice "wiping all testro.tomb* in /tmp"
+    sudo rm -f /tmp/testro.tomb{,.key,.new.key}
+
+    # Create new
+    tt dig -s 20 /tmp/testro.tomb
+    tt forge /tmp/testro.tomb.key \
+        --ignore-swap --unsafe --tomb-pwd ${dummypass} --use-urandom
+    tt lock /tmp/testro.tomb -k /tmp/testro.tomb.key \
+        --ignore-swap --unsafe --tomb-pwd ${dummypass} 
+
+    notice "Testing open read only"
+
+    # Remove write privilege on test.tomb
+    chmod -w /tmp/testro.tomb
+
+    # Attempt to open the unwritable tomb with the read-only mount option
+    tt open /tmp/testro.tomb -k /tmp/testro.tomb.key \
+        --ignore-swap --unsafe --tomb-pwd ${dummypass} -o ro,noatime,nodev
+
+    { test $? = 0 } && {
+        results+=(openro SUCCESS)
+        tt close testro
+    }
+}
 
 
 startloops=(`sudo losetup -a |cut -d: -f1`)
@@ -227,8 +252,8 @@ tt close test
 
 { test $? = 0 } && { results+=(close SUCCESS) }
 
-
-
+# isolated function
+test-open-read-only
 
 
 notice "Testing changing tomb password"

--- a/tomb
+++ b/tomb
@@ -507,7 +507,8 @@ is_valid_tomb() {
 
     _fail=0
     # Tomb file must be a readable, writable, non-empty regular file.
-    [[ ! -w "$1" ]] && {
+    # If passed the "ro" mount option, the writable check is skipped.
+    [[ ! -w "$1" ]] && [[ $(option_value -o) != *"ro"* ]] && {
         _warning "Tomb file is not writable: ::1 tomb file::" $1
         _fail=1
     }


### PR DESCRIPTION
This fixes issue #247.

I tried to do things in the most straightforward and simple way, and attempted to follow the code conventions in `tomb` and `runtests`. Please let me know if there is anything I should improve!

## Changed Behavior

Tomb can now open read-only Tomb files and mount them as a read-only file system. If the string `ro` is detected anywhere in the value of the `-o` option, Tomb skips the check that makes sure the Tomb file is writable.

## Tests

I've added a test that prepares a test tomb file called testro.tomb, removes its write permissions, and tries to open it as a read-only file system with `-o ro,noatime,nodev`. I made this test before changing anything else, then changed the code so it succeeded. I also did some manual testing after everything seemed to be working.

## Example Session

Prepare test Tomb file:

    $ ./tomb dig -s 10 test
    tomb  .	 Commanded to dig tomb test
    tomb (*) Creating a new tomb in test
    tomb  .	 Generating test of 10MiB
    10+0 records in
    10+0 records out
    10485760 bytes (10 MB, 10 MiB) copied, 0.0664588 s, 158 MB/s
    -rw------- 1 amin users 10M Feb 12 18:02 test
    tomb (*) Done digging test
    tomb  .	 Your tomb is not yet ready, you need to forge a key and lock it:
    tomb  .	 tomb forge test.key
    tomb  .	 tomb lock test -k test.key

    $ ./tomb forge test.key
    tomb  .	 An active swap partition is detected...
    [sudo] password for amin:
    tomb (*) The undertaker found that all swap partitions are encrypted. Good.
    tomb  .	 Commanded to forge key test.key with cipher algorithm AES256
    tomb [W] This operation takes time, keep using this computer on other tasks,
    tomb [W] once done you will be asked to choose a password for your tomb.
    tomb [W] To make it faster you can move the mouse around.
    tomb [W] If you are on a server, you can use an Entropy Generation Daemon.
    512+0 records in
    512+0 records out
    512 bytes copied, 67.1647 s, 0.0 kB/s
    tomb (*) Choose the  password of your key: test.key
    tomb  .	 (You can also change it later using 'tomb passwd'.)
    tomb  .	 Key is valid.
    tomb  .	 Done forging test.key
    tomb (*) Your key is ready:
    -rw------- 1 amin users 859 Feb 12 18:04 test.key

    $ ./tomb lock test -k test.key
    tomb  .	 Commanded to lock tomb test
    tomb  .	 Checking if the tomb is empty (we never step on somebody else's bones).
    tomb  .	 Fine, this tomb seems empty.
    tomb  .	 Key is valid.
    tomb  .	 Locking using cipher: aes-xts-plain64:sha256
    tomb  .	 A password is required to use key test.key
    tomb  .	 Password OK.
    tomb (*) Locking test with test.key
    tomb  .	 Formatting Luks mapped device.
    tomb  .	 Formatting your Tomb with Ext3/Ext4 filesystem.
    tomb  .	 Done locking test using Luks dm-crypt aes-xts-plain64:sha256
    tomb (*) Your tomb is ready in test and secured with key test.key

Remove the write permissions:

    $ chmod -w test

    $ ls -l test
    -r-------- 1 amin users 10485760 Feb 12 18:04 test

Opening normally fails:

    $ ./tomb open test -k test.key
    tomb  .	 Commanded to open tomb test
    tomb  .	 An active swap partition is detected...
    tomb (*) The undertaker found that all swap partitions are encrypted. Good.
    tomb [W] Tomb file is not writable: test
    tomb [E] Tomb command failed: open

Opening with `-o ro,noatime,nodev` succeeds:

    $ ./tomb open test -k test.key -o ro,noatime,nodev
    tomb  .	 Commanded to open tomb test
    tomb  .	 An active swap partition is detected...
    tomb (*) The undertaker found that all swap partitions are encrypted. Good.
    tomb  .	 Valid tomb file found: test
    tomb  .	 Key is valid.
    tomb  .	 Mountpoint not specified, using default: /run/media/amin/test
    tomb (*) Opening test on /run/media/amin/test
    tomb  .	 This tomb is a valid LUKS encrypted device.
    tomb  .	 Cipher is "aes" mode "xts-plain64:sha256" hash "sha256"
    tomb  .	 A password is required to use key test.key
    tomb  .	 Password OK.
    tomb (*) Success unlocking tomb test
    tomb  .	 Checking filesystem via /dev/loop7
    fsck from util-linux 2.29.1
    test: clean, 11/2048 files, 1362/8192 blocks
    tomb (*) Success opening test on /run/media/amin/test
    mount_tomb:135: read-only file system: /run/media/amin/test/.uid
    mount_tomb:137: read-only file system: /run/media/amin/test/.tty
    mount_tomb:140: read-only file system: /run/media/amin/test/.host
    mount_tomb:144: read-only file system: /run/media/amin/test/.last

    $ ./tomb close test
    tomb  .	 Closing tomb [test] mounted on /run/media/amin/test
    tomb (*) Tomb [test] closed: your bones will rest in peace.

## Relevant Test Output

    tomb  .	 Testing open read only
    
    tomb [D] Identified caller: amin (1000:100)
    tomb [D] Tomb command: open /tmp/testro.tomb
    tomb [D] Caller: uid[1000], gid[100], tty[/dev/pts/5].
    tomb [D] Temporary directory: /tmp/zsh
    tomb  .	 Commanded to open tomb /tmp/testro.tomb
    tomb [D] is_valid_tomb /tmp/testro.tomb
    tomb [D] tomb file is readable
    tomb [D] tomb file is a regular file
    tomb [D] tomb file is not empty
    tomb [D] tomb file is not currently in use
    tomb  .	 Valid tomb file found: /tmp/testro.tomb
    tomb [D] load_key argument: /tmp/testro.tomb.key
    tomb [D] load_key: /tmp/testro.tomb.key
    tomb [D] is_valid_key
    tomb  .	 Key is valid.
    tomb  .	 Mountpoint not specified, using default: /run/media/amin/testro
    tomb (*) Opening testro on /run/media/amin/testro
    tomb  .	 This tomb is a valid LUKS encrypted device.
    tomb  .	 Cipher is "aes" mode "xts-plain64:sha256" hash "sha256"
    tomb [D] dev mapper device: tomb.testro.1486952323.loop7
    tomb [D] Tomb key: /tmp/testro.tomb.key
    tomb [D] Tomb name: testro (to be engraved)
    tomb [D] tomb-pwd = test
    tomb  .	 A password is required to use key /tmp/testro.tomb.key
    tomb [D] ask_key_password with tombpass: test
    tomb [D] get_lukskey
    tomb [D] Created tempfile: /tmp/zsh/376930900208201791
    tomb [D] gpg: AES256 encrypted data
    tomb [D] [GNUPG:] NEED_PASSPHRASE_SYM 9 3 2
    tomb [D] gpg: encrypted with 1 passphrase
    tomb [D] [GNUPG:] BEGIN_DECRYPTION
    tomb [D] [GNUPG:] DECRYPTION_INFO 2 9
    tomb [D] [GNUPG:] PLAINTEXT 62 1486952313
    tomb [D] [GNUPG:] DECRYPTION_OKAY
    tomb [D] [GNUPG:] GOODMDC
    tomb [D] [GNUPG:] END_DECRYPTION
    tomb [D] get_lukskey returns 0
    tomb  .	 Password OK.
    tomb [D] lo_preserve on /dev/loop7
    tomb (*) Success unlocking tomb testro
    tomb [D] Key size is 512 for cipher aes-xts-plain64:sha256
    tomb  .	 Checking filesystem via /dev/loop7
    fsck from util-linux 2.29.1
    testro: clean, 11/4608 files, 1911/18432 blocks
    tomb [D] Tomb engraved as testro
    tomb (*) Success opening testro.tomb on /run/media/amin/testro
    mount_tomb:135: read-only file system: /run/media/amin/testro/.uid
    mount_tomb:137: read-only file system: /run/media/amin/testro/.tty
    mount_tomb:140: read-only file system: /run/media/amin/testro/.host
    mount_tomb:144: read-only file system: /run/media/amin/testro/.last
    tomb [D] bind-hooks not found in /run/media/amin/testro
    tomb [W]      loop device usage change to 8
        Tomb command returns 0
    tomb [D] Identified caller: amin (1000:100)
    tomb [D] Tomb command: close testro
    tomb [D] Caller: uid[1000], gid[100], tty[/dev/pts/5].
    tomb [D] Temporary directory: /tmp/zsh
    tomb [D] Name: [testro]
    tomb [D] Mount: /run/media/amin/testro
    tomb [D] Mapper: tomb.testro.1486952323.loop7
    tomb  .	 Closing tomb [testro] mounted on /run/media/amin/testro
    tomb [D] Performing umount of /run/media/amin/testro
    tomb (*) Tomb [testro] closed: your bones will rest in peace.
    tomb [W]      loop device usage change to 7
        Tomb command returns 0