### PR TITLE
Options for GnuPG Key

### DIFF
--- a/extras/test/runtests
+++ b/extras/test/runtests
@@ -59,7 +59,7 @@ typeset -A results
 
 tests=(dig forge lock badpass open close passwd chksum bind setkey recip-dig 
 		recip-forge recip-lock recip-open recip-close recip-passwd recip-resize 
-		recip-setkey shared shared-passwd shared-setkey)
+		recip-setkey shared shared-passwd shared-setkey recip-default)
 
 { test $RESIZER = 1 } && { tests+=(resize) }
 { test $KDF = 1 } && { tests+=(kdforge kdfpass kdflock kdfopen) }
@@ -191,6 +191,23 @@ test-tomb-recip() {
     { test $? = 0 } || { res=1 }
     { test $res = 0 } && { results+=(recip-setkey SUCCESS) }
     tt close recip
+}
+
+test-tomb-default() {
+
+	notice "wiping all default.tomb* in /tmp"
+	rm -f /tmp/default.tomb /tmp/default.tomb.key
+	
+	notice "Testing tomb with the default recipient"
+	res=0
+    tt dig -s 20 /tmp/default.tomb
+    { test $? = 0 } || { res=1 }
+    tt forge /tmp/default.tomb.key -g --ignore-swap --unsafe --use-urandom
+    { test $? = 0 } || { res=1 }
+	tt lock /tmp/default.tomb -k /tmp/default.tomb.key \
+        --ignore-swap --unsafe -g
+    { test $? = 0 } || { res=1 }
+    { test $res = 0 } && { results+=(recip-default SUCCESS) }
 }
 
 test-tomb-shared() {
@@ -364,6 +381,7 @@ startloops=(`sudo losetup -a |cut -d: -f1`)
 # isolated function (also called with source)
 test-tomb-create
 test-tomb-recip
+test-tomb-default
 test-tomb-shared
 
 notice "Testing open with wrong password"

--- a/extras/test/runtests
+++ b/extras/test/runtests
@@ -59,7 +59,7 @@ typeset -A results
 
 tests=(dig forge lock badpass open close passwd chksum bind setkey recip-dig 
 		recip-forge recip-lock recip-open recip-close recip-passwd recip-resize 
-		recip-setkey shared shared-passwd shared-setkey recip-default)
+		recip-setkey recip-default recip-hidden shared shared-passwd shared-setkey)
 
 { test $RESIZER = 1 } && { tests+=(resize) }
 { test $KDF = 1 } && { tests+=(kdforge kdfpass kdflock kdfopen) }
@@ -193,7 +193,7 @@ test-tomb-recip() {
     tt close recip
 }
 
-test-tomb-default() {
+test-tomb-recip-default() {
 
 	notice "wiping all default.tomb* in /tmp"
 	rm -f /tmp/default.tomb /tmp/default.tomb.key
@@ -208,6 +208,23 @@ test-tomb-default() {
         --ignore-swap --unsafe -g
     { test $? = 0 } || { res=1 }
     { test $res = 0 } && { results+=(recip-default SUCCESS) }
+}
+
+test-tomb-recip-hidden() {
+
+	notice "wiping all hidden.tomb* in /tmp"
+	rm -f /tmp/hidden.tomb /tmp/hidden.tomb.key
+	
+	notice "Testing tomb with hidden recipient"
+	res=0
+    tt dig -s 20 /tmp/hidden.tomb
+    { test $? = 0 } || { res=1 }
+    tt forge /tmp/hidden.tomb.key -g -R $gpgid_1 --ignore-swap --unsafe --use-urandom
+    { test $? = 0 } || { res=1 }
+	tt lock /tmp/hidden.tomb -k /tmp/hidden.tomb.key \
+        --ignore-swap --unsafe -g -R $gpgid_1
+    { test $? = 0 } || { res=1 }
+    { test $res = 0 } && { results+=(recip-hidden SUCCESS) }
 }
 
 test-tomb-shared() {
@@ -381,7 +398,8 @@ startloops=(`sudo losetup -a |cut -d: -f1`)
 # isolated function (also called with source)
 test-tomb-create
 test-tomb-recip
-test-tomb-default
+test-tomb-recip-default
+test-tomb-recip-hidden
 test-tomb-shared
 
 notice "Testing open with wrong password"

--- a/tomb
+++ b/tomb
@@ -654,6 +654,7 @@ usage() {
     _print " -f     force operation (i.e. even if swap is active)"
     _print " -g     use a GnuPG key to encrypt a tomb key"
     _print " -r     provide GnuPG recipients (separated by coma)"
+    _print " -R     provide GnuPG hidden recipients (separated by coma)"
     _print " --shared active sharing feature"
     [[ $KDF == 1 ]] && {
         _print " --kdf  forge keys armored against dictionary attacks"
@@ -1002,10 +1003,10 @@ gpg_decrypt() {
         gpgpopt=()
         
         # GPG option '--try-secret-key' exist since GPG 2.1
-        { option_is_set -r } && [[ $gpgver =~ "2.1." ]] && {
+        { option_is_set -R } && [[ $gpgver =~ "2.1." ]] && {
             typeset -a recipients
-            recipients=(${(s:,:)$(option_value -r)})
-            { ! is_valid_recipients $recipients } && {
+            recipients=(${(s:,:)$(option_value -R)})
+            { is_valid_recipients $recipients } || {
                  _failure "You set an invalid GPG ID."
             }
             gpgpopt=(`_recipients_arg "--try-secret-key" $recipients`)
@@ -1230,6 +1231,7 @@ gen_key() {
     local algopt="`option_value -o`"
     local algo="${algopt:-AES256}"
     local gpgpass opt
+    local recipients_opt
     typeset -a gpgopt
     # here user is prompted for key password
     tombpass=""
@@ -1237,10 +1239,17 @@ gen_key() {
 
     { option_is_set -g } && {
         gpgopt=(--encrypt)
-        
-        { option_is_set -r } && {
+
+        { option_is_set -r || option_is_set -R } && {
             typeset -a recipients
-            recipients=(${(s:,:)$(option_value -r)})
+            { option_is_set -r } && {
+                recipients=(${(s:,:)$(option_value -r)})
+                recipients_opt="--recipient"
+            } || {
+                recipients=(${(s:,:)$(option_value -R)})
+                recipients_opt="--hidden-recipient"
+            }
+                
             [ "${#recipients}" -gt 1 ] && {
                 if option_is_set --shared; then
                     _warning "You are going to encrypt a tomb key with ${#recipients} recipients."
@@ -1258,7 +1267,7 @@ gen_key() {
                 _failure "You set an invalid GPG ID."
             }
             
-            gpgopt+=(`_recipients_arg "--hidden-recipient" $recipients`)
+            gpgopt+=(`_recipients_arg "$recipients_opt" $recipients`)
         } || {
             _message "No recipient specified, using default GPG key."
             gpgopt+=("--default-recipient-self")
@@ -2754,19 +2763,19 @@ main() {
     main_opts=(q -quiet=q D -debug=D h -help=h v -version=v f -force=f -tmp: U: G: T: -no-color -unsafe g -gpgkey=g)
     subcommands_opts[__default]=""
     # -o in open and mount is used to pass alternate mount options
-    subcommands_opts[open]="n -nohook=n k: -kdf: o: -ignore-swap -tomb-pwd: r: "
+    subcommands_opts[open]="n -nohook=n k: -kdf: o: -ignore-swap -tomb-pwd: r: R: "
     subcommands_opts[mount]=${subcommands_opts[open]}
 
     subcommands_opts[create]="" # deprecated, will issue warning
 
     # -o in forge and lock is used to pass an alternate cipher.
-    subcommands_opts[forge]="-ignore-swap k: -kdf: o: -tomb-pwd: -use-urandom r: -shared "
+    subcommands_opts[forge]="-ignore-swap k: -kdf: o: -tomb-pwd: -use-urandom r: R: -shared "
     subcommands_opts[dig]="-ignore-swap s: -size=s "
-    subcommands_opts[lock]="-ignore-swap k: -kdf: o: -tomb-pwd: r: "
-    subcommands_opts[setkey]="k: -ignore-swap -kdf: -tomb-old-pwd: -tomb-pwd: r: -shared "
+    subcommands_opts[lock]="-ignore-swap k: -kdf: o: -tomb-pwd: r: R: "
+    subcommands_opts[setkey]="k: -ignore-swap -kdf: -tomb-old-pwd: -tomb-pwd: r: R: -shared "
     subcommands_opts[engrave]="k: "
 
-    subcommands_opts[passwd]="k: -ignore-swap -kdf: -tomb-old-pwd: -tomb-pwd: r: -shared "
+    subcommands_opts[passwd]="k: -ignore-swap -kdf: -tomb-old-pwd: -tomb-pwd: r: R: -shared "
     subcommands_opts[close]=""
     subcommands_opts[help]=""
     subcommands_opts[slam]=""
@@ -2776,14 +2785,14 @@ main() {
     subcommands_opts[search]=""
 
     subcommands_opts[help]=""
-    subcommands_opts[bury]="k: -tomb-pwd: r: "
-    subcommands_opts[exhume]="k: -tomb-pwd: r: "
+    subcommands_opts[bury]="k: -tomb-pwd: r: R: "
+    subcommands_opts[exhume]="k: -tomb-pwd: r: R: "
     # subcommands_opts[decompose]=""
     # subcommands_opts[recompose]=""
     # subcommands_opts[install]=""
     subcommands_opts[askpass]=""
     subcommands_opts[source]=""
-    subcommands_opts[resize]="-ignore-swap s: -size=s k: -tomb-pwd: r: "
+    subcommands_opts[resize]="-ignore-swap s: -size=s k: -tomb-pwd: r: R: "
     subcommands_opts[check]="-ignore-swap "
     #    subcommands_opts[translate]=""
 

--- a/tomb
+++ b/tomb
@@ -996,11 +996,11 @@ gpg_decrypt() {
     local gpgpass="$1\n$TOMBKEY"
     local tmpres ret
     typeset -a gpgopt
-    gpgpopt=(--passphrase-fd 0)
+    gpgpopt=(--batch --no-tty --passphrase-fd 0)
 
     { option_is_set -g } && {
         gpgpass="$TOMBKEY"
-        gpgpopt=()
+        gpgpopt=(--yes)
         
         # GPG option '--try-secret-key' exist since GPG 2.1
         { option_is_set -R } && [[ $gpgver =~ "2.1." ]] && {
@@ -1009,14 +1009,14 @@ gpg_decrypt() {
             { is_valid_recipients $recipients } || {
                  _failure "You set an invalid GPG ID."
             }
-            gpgpopt=(`_recipients_arg "--try-secret-key" $recipients`)
+            gpgpopt+=(`_recipients_arg "--try-secret-key" $recipients`)
         }
     }
     
     [[ $gpgver == "1.4.11" ]] && {
         _verbose "GnuPG is version 1.4.11 - adopting status fix."
         TOMBSECRET=`print - "$gpgpass" | \
-            gpg --batch ${gpgpopt[@]} --no-tty --no-options`
+            gpg ${gpgpopt[@]} --no-options`
         ret=$?
         unset gpgpass
         return $ret
@@ -1025,7 +1025,7 @@ gpg_decrypt() {
     _tmp_create
     tmpres=$TOMBTMP
     TOMBSECRET=`print - "$gpgpass" | \
-        gpg --batch ${gpgpopt[@]} --no-tty --no-options \
+        gpg ${gpgpopt[@]} --no-options  \
             --status-fd 2 --no-mdc-warning --no-permission-warning \
             --no-secmem-warning 2> $tmpres`
     unset gpgpass

--- a/tomb
+++ b/tomb
@@ -1236,32 +1236,36 @@ gen_key() {
     tombpasstmp=""
 
     { option_is_set -g } && {
-        { option_is_set -r } || {
-            _failure "A GPG recipient needs to be specified using -r."
-        }
-
-        typeset -a recipients
-        recipients=(${(s:,:)$(option_value -r)})
-        [ "${#recipients}" -gt 1 ] && {
-            if option_is_set --shared; then
-                _warning "You are going to encrypt a tomb key with ${#recipients} recipients."
-                _warning "It is your responsibility to check the fingerprint of these recipients."
-                _warning "The fingerprints are:"
-                for gpg_id in ${recipients[@]}; do
-                    _warning "    `_fingerprint "$gpg_id"`"
-                done
-            else
-                _failure "You need to use the option '--shared' to enable sharing support"
-            fi
-        }
+        gpgopt=(--encrypt)
         
-        { is_valid_recipients $recipients } || {
-            _failure "You set an invalid GPG ID."
+        { option_is_set -r } && {
+            typeset -a recipients
+            recipients=(${(s:,:)$(option_value -r)})
+            [ "${#recipients}" -gt 1 ] && {
+                if option_is_set --shared; then
+                    _warning "You are going to encrypt a tomb key with ${#recipients} recipients."
+                    _warning "It is your responsibility to check the fingerprint of these recipients."
+                    _warning "The fingerprints are:"
+                    for gpg_id in ${recipients[@]}; do
+                        _warning "    `_fingerprint "$gpg_id"`"
+                    done
+                else
+                    _failure "You need to use the option '--shared' to enable sharing support"
+                fi
+            }
+            
+            { is_valid_recipients $recipients } || {
+                _failure "You set an invalid GPG ID."
+            }
+            
+            gpgopt+=(`_recipients_arg "--hidden-recipient" $recipients`)
+        } || {
+            _message "No recipient specified, using default GPG key."
+            gpgopt+=("--default-recipient-self")
         }
         
         # Set gpg inputs and options
         gpgpass="$TOMBSECRET"
-        gpgopt=(--encrypt `_recipients_arg "--hidden-recipient" $recipients`)
         opt=''
     } || {
         if [ "$1" = "" ]; then

--- a/tomb
+++ b/tomb
@@ -1016,7 +1016,7 @@ gpg_decrypt() {
     [[ $gpgver == "1.4.11" ]] && {
         _verbose "GnuPG is version 1.4.11 - adopting status fix."
         TOMBSECRET=`print - "$gpgpass" | \
-            gpg ${gpgpopt[@]} --no-options`
+            gpg --decrypt ${gpgpopt[@]} --no-options`
         ret=$?
         unset gpgpass
         return $ret
@@ -1025,7 +1025,7 @@ gpg_decrypt() {
     _tmp_create
     tmpres=$TOMBTMP
     TOMBSECRET=`print - "$gpgpass" | \
-        gpg ${gpgpopt[@]} --no-options  \
+        gpg --decrypt ${gpgpopt[@]} --no-options  \
             --status-fd 2 --no-mdc-warning --no-permission-warning \
             --no-secmem-warning 2> $tmpres`
     unset gpgpass


### PR DESCRIPTION
This PR tries to fix the few issues related to the GPG option in PR #244.

The new features are:
* Support for GPG default key (by default). Tomb now always use the default-key unless the `-r` (or `-R`) option provides a recipient.
_Note_: when using the default key, the recipient is not hidden.

* The use of hidden recipient is activated when the recipients are provided using the `-R` option. Otherwise, when using the `-r` option, the recipient will not be hidden in the encrypted tomb key.
_Note_: I implemented this feature because it does not always make sense to hide the recipient. Moreover, it adds a layer of complexity for the user: They must provide the (long) recipient, if the tomb is shared side problem appears.

Feedback are welcome. If you do not like a thing in the implementation please tell me, I will be happy to change anything that need to be changed.