### PR TITLE
Options for GnuPG Key - 2

### DIFF
--- a/extras/test/gnupg/gpg.conf
+++ b/extras/test/gnupg/gpg.conf
@@ -1,0 +1,8 @@
+# ~/.gnupg/gpg.conf
+
+# Description of options can be found here:
+# http://www.gnupg.org/documentation/manuals/gnupg-devel/GPG-Options.html
+
+# GPG Configuration Options
+default-key 0B2235E660753AB0475FB3E23DC836481F44B31E
+default-recipient-self

--- a/extras/test/runtests
+++ b/extras/test/runtests
@@ -196,7 +196,7 @@ test-tomb-recip() {
 test-tomb-recip-default() {
 
 	notice "wiping all default.tomb* in /tmp"
-	rm -f /tmp/default.tomb /tmp/default.tomb.key
+	rm -f /tmp/default.tomb /tmp/default.tomb.key /tmp/default.tmp 
 	
 	notice "Testing tomb with the default recipient"
 	res=0
@@ -207,6 +207,8 @@ test-tomb-recip-default() {
 	tt lock /tmp/default.tomb -k /tmp/default.tomb.key \
         --ignore-swap --unsafe -g
     { test $? = 0 } || { res=1 }
+    gpg -d --status-fd 2 /tmp/default.tomb.key 1> /dev/null 2> /tmp/default.tmp 
+    [[ -z "$(grep 'Tomb Test 2' /tmp/default.tmp)" ]] && { res=1 }
     { test $res = 0 } && { results+=(recip-default SUCCESS) }
 }
 

--- a/extras/test/runtests
+++ b/extras/test/runtests
@@ -236,7 +236,7 @@ test-tomb-shared() {
     res=0
     tt dig -s 20 /tmp/shared.tomb
     { test $? = 0 } || { res=1 }
-    tt forge /tmp/shared.tomb.key -g -r $gpgid_1,$gpgid_2 --shared \
+    tt forge /tmp/shared.tomb.key -g -r $gpgid_1,$gpgid_2 \
         --ignore-swap --unsafe --use-urandom 
     { test $? = 0 } || { res=1 }
     tt lock /tmp/shared.tomb -k /tmp/shared.tomb.key \
@@ -249,17 +249,17 @@ test-tomb-shared() {
     { test $res = 0 } && { results+=(shared SUCCESS) }
     
     notice "Testing changing recipients on a shared Tomb"
-    tt passwd -k /tmp/shared.tomb.key -g -r $gpgid_2,$gpgid_1 --shared
+    tt passwd -k /tmp/shared.tomb.key -g -r $gpgid_2,$gpgid_1
     { test $? = 0 } && { results+=(shared-passwd SUCCESS) }
     
     notice "Testing setkey on a shared Tomb"
     rm -f /tmp/new.shared.tomb.key
     res=0
-    tt forge /tmp/new.shared.tomb.key -g -r $gpgid_1,$gpgid_2 --shared\
+    tt forge /tmp/new.shared.tomb.key -g -r $gpgid_1,$gpgid_2 \
         --ignore-swap --unsafe --use-urandom
     { test $? = 0 } || { res=1 }
     tt setkey -k /tmp/new.shared.tomb.key /tmp/shared.tomb.key /tmp/shared.tomb \
-        -g -r $gpgid_2,$gpgid_1 --shared
+        -g -r $gpgid_2,$gpgid_1
     { test $? = 0 } || { res=1 }
     { test $res = 0 } && { results+=(shared-setkey SUCCESS) }
 }

--- a/tomb
+++ b/tomb
@@ -995,7 +995,7 @@ gpg_decrypt() {
     local gpgpass="$1\n$TOMBKEY"
     local tmpres ret
     typeset -a gpgopt
-    gpgpopt=(--batch --no-tty --passphrase-fd 0)
+    gpgpopt=(--batch --no-tty --passphrase-fd 0 --no-options)
 
     { option_is_set -g } && {
         gpgpass="$TOMBKEY"
@@ -1015,7 +1015,7 @@ gpg_decrypt() {
     [[ $gpgver == "1.4.11" ]] && {
         _verbose "GnuPG is version 1.4.11 - adopting status fix."
         TOMBSECRET=`print - "$gpgpass" | \
-            gpg --decrypt ${gpgpopt[@]} --no-options`
+            gpg --decrypt ${gpgpopt[@]}`
         ret=$?
         unset gpgpass
         return $ret
@@ -1024,7 +1024,7 @@ gpg_decrypt() {
     _tmp_create
     tmpres=$TOMBTMP
     TOMBSECRET=`print - "$gpgpass" | \
-        gpg --decrypt ${gpgpopt[@]} --no-options  \
+        gpg --decrypt ${gpgpopt[@]}  \
             --status-fd 2 --no-mdc-warning --no-permission-warning \
             --no-secmem-warning 2> $tmpres`
     unset gpgpass
@@ -1329,15 +1329,15 @@ gen_key() {
 
         # Set gpg inputs and options
         gpgpass="${tombpass}\n$TOMBSECRET"
-        gpgopt=(--passphrase-fd 0 --symmetric)
+        gpgopt=(--passphrase-fd 0 --symmetric --no-options)
         opt='-n'
     }
 
     _tmp_create
     local tmpres=$TOMBTMP
     print $opt - "$gpgpass" \
-        | gpg --openpgp --force-mdc --cipher-algo ${algo} --batch \
-              --no-options --no-tty ${gpgopt[@]} \
+        | gpg --openpgp --force-mdc --cipher-algo ${algo} \
+              --batch --no-tty ${gpgopt[@]} \
               --status-fd 2 -o - --armor 2> $tmpres
     unset gpgpass
     # check result of gpg operation

--- a/tomb
+++ b/tomb
@@ -943,12 +943,7 @@ _load_key() {
     [[ -z $keyfile ]] && {
         _failure "This operation requires a key file to be specified using the -k option." }
 
-    if option_is_set -g; then
-        _verbose "load_key key encrypted with a GnuPG Key"
-        _message "Key encrypted with a GnuPG Key"
-        TOMBKEYFILE=$keyfile
-        TOMBKEY="${mapfile[$TOMBKEYFILE]}"
-    elif [[ $keyfile == "-" ]]; then
+    if [[ $keyfile == "-" ]]; then
         _verbose "load_key reading from stdin."
         _message "Waiting for the key to be piped from stdin... "
         TOMBKEYFILE=stdin

--- a/tomb
+++ b/tomb
@@ -655,7 +655,6 @@ usage() {
     _print " -g     use a GnuPG key to encrypt a tomb key"
     _print " -r     provide GnuPG recipients (separated by coma)"
     _print " -R     provide GnuPG hidden recipients (separated by coma)"
-    _print " --shared active sharing feature"
     [[ $KDF == 1 ]] && {
         _print " --kdf  forge keys armored against dictionary attacks"
     }
@@ -1249,23 +1248,17 @@ gen_key() {
                 recipients=(${(s:,:)$(option_value -R)})
                 recipients_opt="--hidden-recipient"
             }
-                
-            [ "${#recipients}" -gt 1 ] && {
-                if option_is_set --shared; then
-                    _warning "You are going to encrypt a tomb key with ${#recipients} recipients."
-                    _warning "It is your responsibility to check the fingerprint of these recipients."
-                    _warning "The fingerprints are:"
-                    for gpg_id in ${recipients[@]}; do
-                        _warning "    `_fingerprint "$gpg_id"`"
-                    done
-                else
-                    _failure "You need to use the option '--shared' to enable sharing support"
-                fi
-            }
             
             { is_valid_recipients $recipients } || {
                 _failure "You set an invalid GPG ID."
             }
+                
+            _warning "You are going to encrypt a tomb key with ${#recipients} recipient(s)."
+            _warning "It is your responsibility to check these fingerprints."
+            _warning "The fingerprints are:"
+            for gpg_id in ${recipients[@]}; do
+               _warning "    `_fingerprint "$gpg_id"`"
+            done
             
             gpgopt+=(`_recipients_arg "$recipients_opt" $recipients`)
         } || {
@@ -1639,13 +1632,12 @@ dig_tomb() {
 
 # Step two -- Create a detached key to lock a tomb with
 #
-# Synopsis: forge_key [destkey|-k destkey] [-o cipher] [-r gpgid] [--shared]
+# Synopsis: forge_key [destkey|-k destkey] [-o cipher] [-r|-R gpgid]
 #
 # Arguments:
 # -k                path to destination keyfile
 # -o                Use an alternate algorithm
 # -r                GPG recipients to be used
-# --shared          Activate sharing capability
 #
 forge_key() {
     # can be specified both as simple argument or using -k
@@ -1708,11 +1700,7 @@ forge_key() {
     # Here the global variable TOMBSECRET contains the naked secret
 
     { option_is_set -g } && {
-        { option_is_set --shared } && {
-            _success "Using GnuPG keys to encrypt and share your key: ::1 tomb key::" $TOMBKEYFILE
-        } || {
-            _success "Using the GnuPG key ::1:: to encrypt the key: ::2 tomb key::" `option_value -r` $TOMBKEYFILE
-        }
+        _success "Using GnuPG key(s) to encrypt your key: ::1 tomb key::" $TOMBKEYFILE
     } || {
         _success "Choose the password of your key: ::1 tomb key::" $TOMBKEYFILE
     }
@@ -2769,13 +2757,13 @@ main() {
     subcommands_opts[create]="" # deprecated, will issue warning
 
     # -o in forge and lock is used to pass an alternate cipher.
-    subcommands_opts[forge]="-ignore-swap k: -kdf: o: -tomb-pwd: -use-urandom r: R: -shared "
+    subcommands_opts[forge]="-ignore-swap k: -kdf: o: -tomb-pwd: -use-urandom r: R: "
     subcommands_opts[dig]="-ignore-swap s: -size=s "
     subcommands_opts[lock]="-ignore-swap k: -kdf: o: -tomb-pwd: r: R: "
-    subcommands_opts[setkey]="k: -ignore-swap -kdf: -tomb-old-pwd: -tomb-pwd: r: R: -shared "
+    subcommands_opts[setkey]="k: -ignore-swap -kdf: -tomb-old-pwd: -tomb-pwd: r: R: "
     subcommands_opts[engrave]="k: "
 
-    subcommands_opts[passwd]="k: -ignore-swap -kdf: -tomb-old-pwd: -tomb-pwd: r: R: -shared "
+    subcommands_opts[passwd]="k: -ignore-swap -kdf: -tomb-old-pwd: -tomb-pwd: r: R: "
     subcommands_opts[close]=""
     subcommands_opts[help]=""
     subcommands_opts[slam]=""


### PR DESCRIPTION
This PR does three things:
* Remove `--shared`. See #252
*  Support for gpg encrypted tomb key loaded from stdin. See #255
* Fix a few issues regarding GPG default key. 
  - Remove `--no-options` gpg option when using GPG key.
  - Improve gpg default key tests

To use the default key, `~/.gnupg/gpg.conf` needs:
```
default-key <keyid>
default-recipient-self
```
Or
```
default-recipient <keyid>
```
Otherwise the first key in the keyring is used.

They will be other changes in the future regarding wrong use of `-g` option and issue with pinentry. I don't know when they'll be ready, they could be the purpose of an other PR. # #