### PR TITLE
Missing lsof stuff

### DIFF
--- a/extras/test/10_operations.sh
+++ b/extras/test/10_operations.sh
@@ -21,4 +21,15 @@ test_expect_success 'Testing open in read only mode' '
     chmod +w $tomb
     '
 
+if test_have_prereq LSOF; then
+    gcc -Wall -o $TMP/close_block $TEST_HOME/close_block.c
+    test_expect_success 'Testing functionality of the slam operation (use of lsof)' '
+        mkdir $TMP/testmount &&
+        tt_open $TMP/testmount --tomb-pwd $DUMMYPASS &&
+        tt_set_ownership $TMP/testmount &&
+        $TMP/close_block $TMP/testmount/occupied 20 &
+        tt slam
+        '
+fi
+
 test_done

--- a/extras/test/Makefile
+++ b/extras/test/Makefile
@@ -24,7 +24,7 @@ RM ?= rm -f
 PROVE ?= prove
 AGGREGATE_SCRIPT ?= aggregate-results
 DEFAULT_TEST_TARGET ?= test
-TEST_OPTS ?= --verbose --immediate --chain-lint --root=/tmp/tomb/sharness
+TEST_OPTS ?= --verbose --immediate --root=/tmp/tomb/sharness
 
 T = $(sort $(wildcard *.sh))
 

--- a/extras/test/close_block.c
+++ b/extras/test/close_block.c
@@ -1,0 +1,41 @@
+/*
+ * Small program which simply opens a file in a tomb to block the
+ *  $ tomb close
+ * operation
+ *
+ * Hard coded assumption on command line arguments
+ * 2) Path to open
+ * 3) How long to open the file (in seconds and can be optional)
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+
+int main(int argc, char const *argv[]) {
+    FILE *file_ptr;
+    unsigned int to_wait=10;
+
+    if ( argc < 2 ) {
+        fprintf(stderr, "Usage: %s path [time]\n", argv[0]);
+        exit(EXIT_FAILURE);
+    }
+
+    if ( argc == 3 ) {
+        to_wait = atoi(argv[2]);
+    }
+
+    file_ptr = fopen(argv[1],"w");
+
+    if ( file_ptr == NULL ) {
+        fprintf(stderr, "Error while opening the file.\n");
+        exit(EXIT_FAILURE);
+    }
+
+    sleep(to_wait);
+
+    fclose(file_ptr);
+
+    return 0;
+}

--- a/extras/test/setup
+++ b/extras/test/setup
@@ -51,6 +51,7 @@ command -v steghide > /dev/null && test_set_prereq STEGHIDE
 command -v e2fsck resize2fs > /dev/null && test_set_prereq RESIZER
 command -v tomb-kdb-pbkdf2 > /dev/null && test_set_prereq KDF
 command -v qrencode > /dev/null && test_set_prereq QRENCODE
+command -v lsof > /dev/null && test_set_prereq LSOF
 
 
 # GnuPG config

--- a/tomb
+++ b/tomb
@@ -782,7 +782,7 @@ function _print() {
 _list_optional_tools() {
     typeset -a _deps
     _deps=(gettext dcfldd wipe steghide)
-    _deps+=(resize2fs tomb-kdb-pbkdf2 qrencode swish-e unoconv)
+    _deps+=(resize2fs tomb-kdb-pbkdf2 qrencode swish-e unoconv lsof)
     for d in $_deps; do
         _print "`which $d`"
     done


### PR DESCRIPTION
PR for the missing stuff since the reintroduction of lsof for slam operation, which means it is now included in --version and a testcase was added.

Thanks to @roddhjav for help with it.

Any missing stuff, or something that should be changed, etc?