### PR TITLE
drop zsh/regex module in favor of =~

### DIFF
--- a/tomb
+++ b/tomb
@@ -65,7 +65,6 @@ WIPE=(rm -f)
 PINENTRY=(pinentry)
 
 # load zsh regex module
-zmodload zsh/regex
 zmodload zsh/mapfile
 zmodload -F zsh/stat b:zstat
 
@@ -2680,7 +2679,7 @@ umount_tomb() {
         tombname_regex=${tombname//\[/}
         tombname_regex=${tombname_regex//\]/}
 
-        [[ "$tombmount" -regex-match "[/run]?/media[/$_USER]?/$tombname_regex" ]] && {
+        [[ "$tombmount" =~ "(/run)?/media(/$_USER)?/$tombname_regex" ]] && {
             _sudo rmdir $tombmount }
 
         _sudo cryptsetup luksClose $mapper ||


### PR DESCRIPTION
As debated in issue #282 Zsh introduced a bug in v5.3.1 which briefly affected
our mechanism for closing tombs. The bug is fixed, but while investigating the
issue @aude realised there can be a better way to apply this regex for the
detection of mounted volumes on distro dependent /run/media/$USER paths.

This change drops usage of the regex optional module in Zsh to use the built-in
=~ comparison and improves the match using round parenthesis. It may fix the
close command on some distributions.