### PR TITLE
Replace 'mount -l' with 'findmnt'

### DIFF
--- a/tomb
+++ b/tomb
@@ -2274,8 +2274,12 @@ BEGIN { main="" }
 '
     } || {
         # list a specific tomb
+		# add square parens if not present (detection)
+		local tname
+		if [[ "${1[1]}" = "[" ]]; then tname="$1"
+		else tname="[$1]"; fi
         _sudo findmnt -rvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
-            | awk -vtomb="[$1]" '
+            | awk -vtomb="$tname" '
 BEGIN { main="" }
 /^\/dev\/mapper\/tomb/ {
   if("["$5"]"!=tomb) next;

--- a/tomb
+++ b/tomb
@@ -65,7 +65,6 @@ WIPE=(rm -f)
 PINENTRY=(pinentry)
 
 # load zsh regex module
-zmodload zsh/regex
 zmodload zsh/mapfile
 zmodload -F zsh/stat b:zstat
 
@@ -2664,7 +2663,7 @@ umount_tomb() {
         tombname_regex=${tombname//\[/}
         tombname_regex=${tombname_regex//\]/}
 
-        [[ "$tombmount" -regex-match "[/run]?/media[/$_USER]?/$tombname_regex" ]] && {
+        [[ "$tombmount" =~ "(/run)?/media(/$_USER)?/$tombname_regex" ]] && {
             _sudo rmdir $tombmount }
 
         _sudo cryptsetup luksClose $mapper ||

--- a/tomb
+++ b/tomb
@@ -549,9 +549,9 @@ is_valid_tomb() {
     _plot $1     # Set TOMB{PATH,DIR,FILE,NAME}
 
     # Tomb already mounted (or we cannot alter it)
-	[[ "`mount -l |
+	[[ "`_sudo findmnt -lrvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL |
         awk -vtomb="[$TOMBNAME]" '
-/^\/dev\/mapper\/tomb/ { if($7==tomb) print $1 }'`" = "" ]] || {
+/^\/dev\/mapper\/tomb/ { if($5==tomb) print $1 }'`" = "" ]] || {
         _failure "Tomb is currently in use: ::1 tomb name::" $TOMBNAME
     }
 	_verbose "tomb file is not currently in use"
@@ -2264,27 +2264,24 @@ awk "/mapper/"' { print $2 ";" $3 ";" $4 ";" $5 }'`
 list_tomb_mounts() {
     [[ -z "$1" ]] && {
         # list all open tombs
-        mount -l \
+        _sudo findmnt -lrvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
             | awk '
 BEGIN { main="" }
 /^\/dev\/mapper\/tomb/ {
   if(main==$1) next;
-  print $1 ";" $3 ";" $5 ";" $6 ";" $7
+  print $1 ";" $2 ";" $3 ";(" $4 ");[" $5 "]"
   main=$1
 }
 '
-    } || { # list a specific tomb
-		# add square parens if not present
-		local tname
-		if [[ "${1[1]}" = "[" ]]; then tname=$1
-		else tname="[$1]"; fi
-        mount -l \
-            | awk -vtomb="$tname" '
+    } || {
+        # list a specific tomb
+        _sudo findmnt -lrvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
+            | awk -vtomb="[$1]" '
 BEGIN { main="" }
 /^\/dev\/mapper\/tomb/ {
-  if($7!=tomb) next;
+  if("["$5"]"!=tomb) next;
   if(main==$1) next;
-  print $1 ";" $3 ";" $5 ";" $6 ";" $7
+  print $1 ";" $2 ";" $3 ";(" $4 ");[" $5 "]"
   main=$1
 }
 '
@@ -2300,37 +2297,23 @@ list_tomb_binds() {
     [[ -z "$2" ]] && {
         _failure "Internal error: list_tomb_binds called without argument." }
 
-    # OK well, prepare for some insanity: parsing the mount table on GNU/Linux
-    # is like combing a Wookie while he is riding a speedbike down a valley.
+    # much simpler than the crazy from before
+    # in fact, the second parameter is now redundant
+    # as we only need the tomb name
 
-    typeset -A tombs
-    typeset -a binds
-    for t in "${(f)$(mount -l | grep '/dev/mapper/tomb.*]$')}"; do
-        len="${(w)#t}"
-        [[ "${t[(w)$len]}" = "$1" ]] || continue
-        tombs+=( ${t[(w)1]} ${t[(w)$len]} )
+    # note that this code assumes that the tomb name is provided in square brackets
 
-    done
-
-    for m in ${(k)tombs}; do
-        for p in "${(f)$(cat /proc/mounts):s/\\040(deleted)/}"; do
-            # Debian's kernel appends a '\040(deleted)' to the mountpoint in /proc/mounts
-            # so if we parse the string as-is then this will break the parsing. How nice of them!
-            # Some bugs related to this are more than 10yrs old. Such Debian! Much stable! Very parsing!
-            # Bug #711183  umount parser for /proc/mounts broken on stale nfs mount (gets renamed to "/mnt/point (deleted)")
-            # Bug #711184  mount should not stat mountpoints on mount
-            # Bug #711187  linux-image-3.2.0-4-amd64: kernel should not rename mountpoint if nfs server is dead/unreachable
-            [[ "${p[(w)1]}" = "$m" ]] && {
-                [[ "${(q)p[(w)2]}" != "${(q)2}" ]] && {
-                    # Our output format:
-                    # mapper;mountpoint;fs;flags;name
-                    binds+=("$m;${(q)p[(w)2]};${p[(w)3]};${p[(w)4]};${tombs[$m]}") }
-            }
-        done
-    done
-
-    # print the results out line by line
-    for b in $binds; do print - "$b"; done
+    _sudo findmnt -lro SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
+            | grep -F "/dev/mapper/tomb" \
+            | awk -vpattern="$1" '
+BEGIN { }
+{
+  if("["$5"]"!=pattern) next;
+  if(index($1,"[")==0) next;
+  gsub("[[][^]]*[]]","",$1);
+  print $1 ";" $2 ";" $3 ";(" $4 ");[" $5 "]"
+}
+'
 }
 
 # }}} - Tomb list
@@ -2519,8 +2502,8 @@ resize_tomb() {
     _load_key # Try loading new key from option -k and set TOMBKEYFILE
 
     local oldtombsize=$(( `stat -c %s "$TOMBPATH" 2>/dev/null` / 1048576 ))
-    local mounted_tomb=`mount -l |
-        awk -vtomb="[$TOMBNAME]" '/^\/dev\/mapper\/tomb/ { if($7==tomb) print $1 }'`
+    local mounted_tomb=`_sudo findmnt -lrvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL |
+        awk -vtomb="[$TOMBNAME]" '/^\/dev\/mapper\/tomb/ { if($5==tomb) print $1 }'`
 
     # Tomb must not be open
     [[ -z "$mounted_tomb" ]] || {
@@ -2613,6 +2596,7 @@ umount_tomb() {
     for t in ${mounted_tombs}; do
         mapper=`basename ${t[(ws:;:)1]}`
 
+        # strip square parens from tombname
         tombname=${t[(ws:;:)5]}
         tombmount=${t[(ws:;:)2]}
         tombfs=${t[(ws:;:)3]}

--- a/tomb
+++ b/tomb
@@ -548,7 +548,7 @@ is_valid_tomb() {
     _plot $1     # Set TOMB{PATH,DIR,FILE,NAME}
 
     # Tomb already mounted (or we cannot alter it)
-	[[ "`_sudo findmnt -lrvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL |
+	[[ "`_sudo findmnt -rvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL |
         awk -vtomb="[$TOMBNAME]" '
 /^\/dev\/mapper\/tomb/ { if($5==tomb) print $1 }'`" = "" ]] || {
         _failure "Tomb is currently in use: ::1 tomb name::" $TOMBNAME
@@ -2263,7 +2263,7 @@ awk "/mapper/"' { print $2 ";" $3 ";" $4 ";" $5 }'`
 list_tomb_mounts() {
     [[ -z "$1" ]] && {
         # list all open tombs
-        _sudo findmnt -lrvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
+        _sudo findmnt -rvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
             | awk '
 BEGIN { main="" }
 /^\/dev\/mapper\/tomb/ {
@@ -2274,7 +2274,7 @@ BEGIN { main="" }
 '
     } || {
         # list a specific tomb
-        _sudo findmnt -lrvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
+        _sudo findmnt -rvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
             | awk -vtomb="[$1]" '
 BEGIN { main="" }
 /^\/dev\/mapper\/tomb/ {
@@ -2302,7 +2302,7 @@ list_tomb_binds() {
 
     # note that this code assumes that the tomb name is provided in square brackets
 
-    _sudo findmnt -lro SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
+    _sudo findmnt -ro SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
             | grep -F "/dev/mapper/tomb" \
             | awk -vpattern="$1" '
 BEGIN { }
@@ -2501,7 +2501,7 @@ resize_tomb() {
     _load_key # Try loading new key from option -k and set TOMBKEYFILE
 
     local oldtombsize=$(( `stat -c %s "$TOMBPATH" 2>/dev/null` / 1048576 ))
-    local mounted_tomb=`_sudo findmnt -lrvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL |
+    local mounted_tomb=`_sudo findmnt -rvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL |
         awk -vtomb="[$TOMBNAME]" '/^\/dev\/mapper\/tomb/ { if($5==tomb) print $1 }'`
 
     # Tomb must not be open


### PR DESCRIPTION
This fixes a mount-related functionality (finding the volume label) in new versions of util-linux, that since v2.30 does not list anymore volume labels with its mount -l command. Since findmnt needs sudo to list labels, this also introduces the need for sudo in more commands: is_valid_tomb(), list, index and search. The issue was examined in PR #283 and this is a rebase of it.
