### PR TITLE
Fixes: version check & tests

### DIFF
--- a/extras/test/40_regression.sh
+++ b/extras/test/40_regression.sh
@@ -3,10 +3,11 @@
 export test_description="Tomb regression tests"
 
 source ./setup
+autoload -U is-at-least
 
 TOMB_VERSION=("2.3" "2.2" "2.0.1" "2.1")
 zshversion=$(zsh --version | awk 'NR==1 {print $2}')
-[[ $zshversion =~ "5.3" ]] && TOMB_VERSION=("2.3")
+{ is-at-least "5.3" $zshversion } && TOMB_VERSION=("2.3")
 
 for version in "${TOMB_VERSION[@]}"; do
     URL="https://files.dyne.org/tomb/old-releases/Tomb-$version.tar.gz"

--- a/extras/test/Makefile
+++ b/extras/test/Makefile
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see http://www.gnu.org/licenses/ .
 
-SHELL := /usr/bin/zsh
+SHELL := $(shell which zsh)
 SHELL_PATH ?= $(SHELL)
 SHELL_PATH_SQ = $(subst ','\'',$(SHELL_PATH))
 RM ?= rm -f

--- a/extras/test/aggregate-results
+++ b/extras/test/aggregate-results
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env zsh
 #
 # Copyright (c) 2008-2012 Git project
 #

--- a/extras/test/setup
+++ b/extras/test/setup
@@ -72,7 +72,6 @@ export DUMMYPASSNEW=changetest
 
 test_cleanup() {
 	"${T}" slam all &> /dev/null
-	rm -f "/home/$USER/dyne-tomb-bind-test-"*
 	sudo rm -rf "$TMP"
 	mkdir -p "$TMP"
 }

--- a/tomb
+++ b/tomb
@@ -1002,7 +1002,7 @@ gpg_decrypt() {
         gpgpopt=(--yes)
         
         # GPG option '--try-secret-key' exist since GPG 2.1
-        { option_is_set -R } && [[ $gpgver =~ "2.1." ]] && {
+        { option_is_set -R } && { autoload -U is-at-least && is-at-least "2.1" $gpgver } && {
             typeset -a recipients
             recipients=(${(s:,:)$(option_value -R)})
             { is_valid_recipients $recipients } || {


### PR DESCRIPTION
Hi @jaromil 

As it seems you are going to do a release soon, there are a few fixes I have on my local system and that can be merged quite easily:
* Use the zsh function `is-at-least` instead of `=~` to check program version.
* Support non-standard zsh location in the test suite. See #283
* Remove useless cleanup in test setup.

Regards,
Alex