### PR TITLE
Fixes a problem reading passwords when using the kdf wrapper  

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ before_script:
   - sudo make --directory=extras/kdf-keys install
 
 script:
+  - make --directory=extras/kdf-keys test
   - make test

--- a/extras/kdf-keys/Makefile
+++ b/extras/kdf-keys/Makefile
@@ -7,6 +7,10 @@ all:
 	$(CC) -O2 -o tomb-kdb-pbkdf2-gensalt gen_salt.c -lgcrypt
 	$(CC) -O2 -o tomb-kdb-hexencode hexencode.c
 
+test:
+	@echo "Running Tomb-kdb tests"
+	./test.sh
+
 clean:
 	rm -f tomb-kdb-pbkdf2 tomb-kdb-pbkdf2-getiter tomb-kdb-pbkdf2-gensalt tomb-kdb-hexencode
 

--- a/extras/kdf-keys/pbkdf2.c
+++ b/extras/kdf-keys/pbkdf2.c
@@ -43,8 +43,8 @@
 
 #include <gcrypt.h>
 
-/* Max password size */
-#define BUFFER_SIZE 1024
+/* block size for password buffer */
+#define BLOCK_SIZE 40
 
 /* TODO: move print_hex and hex_to_binary to utils.h, with separate compiling */
 void print_hex(unsigned char *buf, int len)
@@ -76,15 +76,37 @@ int hex_to_binary(unsigned char *buf, char *hex)
 	return count;
 }
 
+void cleanup(char *result, int result_len, char *pass, char *salt, int salt_len) {
+	int i;
+
+	//clear and free everything
+	if (result) {
+		for(i=0; i<result_len;i++)
+			result[i]=0;
+		free(result);
+	}
+	if (pass) {
+		for(i=0; i<strlen(pass); i++) //blank
+			pass[i]=0;
+		free(pass);
+	}
+	if (salt) {
+		for(i=0; i<salt_len; i++) //blank
+			salt[i]=0;
+		free(salt);
+	}
+}
+
 int main(int argc, char *argv[])
 {
-	char pass[BUFFER_SIZE];
-	unsigned char *salt;
+	char *pass = NULL;
+	unsigned char *salt = NULL;
 	int salt_len;                  // salt length in bytes
 	int ic=0;                        // iterative count
 	int result_len;
-	unsigned char *result;       // result (binary - 32+16 chars)
-	int i, pw_lenght;
+	unsigned char *result = NULL;       // result (binary - 32+16 chars)
+	int i, pw_len = 0;
+	int buff_len = BLOCK_SIZE;
 
 	if ( argc != 4 ) {
 		fprintf(stderr, "usage: %s salt count len <passwd >binary_key_iv\n", argv[0]);
@@ -92,7 +114,8 @@ int main(int argc, char *argv[])
 	}
 
 	//TODO: move to base64decode
-	salt=calloc(strlen(argv[1])/2+3, sizeof(char));
+	salt_len = strlen(argv[1])/2+3;
+	salt = calloc(salt_len, sizeof(char));
 	salt_len=hex_to_binary(salt, argv[1]);
 	if( salt_len <= 0 ) {
 		fprintf(stderr, "Error: %s is not a valid salt (it must be a hexadecimal string)\n", argv[1]);
@@ -115,26 +138,34 @@ int main(int argc, char *argv[])
 	 *
 	 * passwords containing just a bunch of spaces are valid
 	 */
-	while (pw_lenght <= BUFFER_SIZE) {
-		char c = getchar();
-		if (c == EOF) break;
-		pass[pw_lenght] = c;
-		pw_lenght++;
+	pass = calloc(buff_len, sizeof(char)); 
+	char c = getchar();
+	while (c != EOF) {
+		if (pw_len == buff_len) {
+			buff_len *= 2;
+			pass = realloc(pass, buff_len);
+			if (!pass) {
+				fprintf(stderr, "Error allocating memory");
+				cleanup(result, result_len, pass, salt, salt_len);
+				exit(3);
+			}
+		}
+		pass[pw_len] = c;
+		pw_len++;
+		c = getchar();
 	}
-	if (pw_lenght > BUFFER_SIZE) {
-		fprintf(stderr, "Error: password is too long\n");
-		exit(1);
-	}
-	if (pw_lenght <= 1) {
+	if (pw_len <= 1) {
 		fprintf(stderr, "Error: password is empty\n");
+		cleanup(result, result_len, pass, salt, salt_len);
 		exit(1);
 	}
-	pass[pw_lenght-1] = '\0';
+	pass[pw_len-1] = '\0';
 
 	// PBKDF 2
 	result = calloc(result_len, sizeof(unsigned char*));
 	if (!gcry_check_version ("1.5.0")) {
 		fputs ("libgcrypt version mismatch\n", stderr);
+		cleanup(result, result_len, pass, salt, salt_len);
 		exit (2);
 	}
 	/* Allocate a pool of 16k secure memory.  This make the secure memory
@@ -146,18 +177,10 @@ int main(int argc, char *argv[])
 	/* Tell Libgcrypt that initialization has completed. */
 	gcry_control (GCRYCTL_INITIALIZATION_FINISHED, 0);
 
-	gcry_kdf_derive(pass, pw_lenght-1, GCRY_KDF_PBKDF2, GCRY_MD_SHA1, salt, salt_len, ic, result_len, result);
+	gcry_kdf_derive(pass, pw_len-1, GCRY_KDF_PBKDF2, GCRY_MD_SHA1, salt, salt_len, ic, result_len, result);
 	print_hex(result, result_len);            // Key + IV   (as hex string)
 
-	//clear and free everything
-	for(i=0; i<result_len;i++)
-		result[i]=0;
-	free(result);
-	for(i=0; i<strlen(pass); i++) //blank
-		pass[i]=0;
-	for(i=0; i<strlen(argv[1])/2+3; i++) //blank
-		salt[i]=0;
-	free(salt);
+	cleanup(result, result_len, pass, salt, salt_len);
 
 	return(0);
 }

--- a/extras/kdf-keys/pbkdf2.c
+++ b/extras/kdf-keys/pbkdf2.c
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
 	int ic=0;                        // iterative count
 	int result_len;
 	unsigned char *result;       // result (binary - 32+16 chars)
-	int i;
+	int i, j;
 
 	if ( argc != 4 ) {
 		fprintf(stderr, "usage: %s salt count len <passwd >binary_key_iv\n", argv[0]);
@@ -111,19 +111,24 @@ int main(int argc, char *argv[])
 	/* Read password char by char.
 	 *
 	 * Doing in this way we make sure that blanks (even null bytes) end up
-	 * in the password
+	 * in the password.
+	 *
+	 * passwords containing just a bunch of spaces are valid
 	 */
-	int j = 0;
 	while (j < (BUFFER_SIZE + 1)) {
 		char c = getchar();
 		if (c == EOF) break;
 		pass[j] = c;
 		j++;
 	}
-	if (j == BUFFER_SIZE + 1) {
+	if (j >= BUFFER_SIZE + 1) {
 		fprintf(stderr, "Error: password is too long\n");
 		exit(1);
-		}
+	}
+	if (j <= 1) {
+		fprintf(stderr, "Error: password is empty\n");
+		exit(1);
+	}
 	pass[j-1] = '\0';
 
 	// PBKDF 2

--- a/extras/kdf-keys/pbkdf2.c
+++ b/extras/kdf-keys/pbkdf2.c
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
 	int ic=0;                        // iterative count
 	int result_len;
 	unsigned char *result;       // result (binary - 32+16 chars)
-	int i, j;
+	int i, pw_lenght;
 
 	if ( argc != 4 ) {
 		fprintf(stderr, "usage: %s salt count len <passwd >binary_key_iv\n", argv[0]);
@@ -115,21 +115,21 @@ int main(int argc, char *argv[])
 	 *
 	 * passwords containing just a bunch of spaces are valid
 	 */
-	while (j < (BUFFER_SIZE + 1)) {
+	while (pw_lenght <= BUFFER_SIZE) {
 		char c = getchar();
 		if (c == EOF) break;
-		pass[j] = c;
-		j++;
+		pass[pw_lenght] = c;
+		pw_lenght++;
 	}
-	if (j >= BUFFER_SIZE + 1) {
+	if (pw_lenght > BUFFER_SIZE) {
 		fprintf(stderr, "Error: password is too long\n");
 		exit(1);
 	}
-	if (j <= 1) {
+	if (pw_lenght <= 1) {
 		fprintf(stderr, "Error: password is empty\n");
 		exit(1);
 	}
-	pass[j-1] = '\0';
+	pass[pw_lenght-1] = '\0';
 
 	// PBKDF 2
 	result = calloc(result_len, sizeof(unsigned char*));
@@ -146,7 +146,7 @@ int main(int argc, char *argv[])
 	/* Tell Libgcrypt that initialization has completed. */
 	gcry_control (GCRYCTL_INITIALIZATION_FINISHED, 0);
 
-	gcry_kdf_derive(pass, j-1, GCRY_KDF_PBKDF2, GCRY_MD_SHA1, salt, salt_len, ic, result_len, result);
+	gcry_kdf_derive(pass, pw_lenght-1, GCRY_KDF_PBKDF2, GCRY_MD_SHA1, salt, salt_len, ic, result_len, result);
 	print_hex(result, result_len);            // Key + IV   (as hex string)
 
 	//clear and free everything

--- a/extras/kdf-keys/pbkdf2.c
+++ b/extras/kdf-keys/pbkdf2.c
@@ -108,6 +108,11 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
+	/* Read password char by char.
+	 *
+	 * Doing in this way we make sure that blanks (even null bytes) end up
+	 * in the password
+	 */
 	int j = 0;
 	while (j < (BUFFER_SIZE + 1)) {
 		char c = getchar();

--- a/extras/kdf-keys/test.sh
+++ b/extras/kdf-keys/test.sh
@@ -1,21 +1,49 @@
 #!/usr/bin/env zsh
 
 error=0
-while read line; do
-	pass=`cut -f1 <<<$line`
-	salt=`cut -f2 <<<$line`
-	iter=`cut -f3 <<<$line`
-	keylen=`cut -f4 <<<$line`
-	expected=`cut -f5 <<<$line`
-	hexsalt=`cut -f6 <<<$line`
-	#TODO: check!
-	derived=`./pbkdf2 $hexsalt $iter $keylen <<<$pass`
-	if [[ $derived != $expected ]]; then
-		echo ./pbkdf2 $hexsalt $iter $keylen "<<<$pass"
-		echo "Expected $expected, got $derived" >&2
-		error=$((error + 1))
-	fi
-done < test.txt
+
+check_kdf() {
+	while read line; do
+		pass=`cut -f1 <<<$line`
+		salt=`cut -f2 <<<$line`
+		iter=`cut -f3 <<<$line`
+		keylen=`cut -f4 <<<$line`
+		expected=`cut -f5 <<<$line`
+		hexsalt=`cut -f6 <<<$line`
+		#TODO: check!
+		derived=`./tomb-kdb-pbkdf2 $hexsalt $iter $keylen <<<$pass`
+		if [[ $derived != $expected ]]; then
+			echo "Expected $expected, got $derived" >&2
+			error=$((error + 1))
+		fi
+	done < test.txt
+}	
+
+check_white_spaces() {
+	hexsalt="73616c74"
+	iter=4096
+	keylen=20
+	typeset -a results
+	passwords=('one two three' 'one two' 'one')
+	for pwd in $passwords; do
+		results+=`./tomb-kdb-pbkdf2 $hexsalt $iter $keylen <<<$pwd`
+	done
+	for ((i=1;i<=3;i++)); do
+		d1=$results[$i]
+		i1=$passwords[$i]
+		for ((j=(($i+1));j<=3;j++)); do
+			d2=$results[$j]
+			i2=$passwords[$j]
+			if [[ $d1 == $d2 ]]; then
+				echo "Inputs \"$i1\" and \"$i2\" produce the same output $d1" >&2
+				error=$((error + 1))
+			fi
+		done
+	done
+}
+
+check_kdf
+check_white_spaces
 
 if [[ $error == 1 ]]; then
 	exit $error

--- a/extras/kdf-keys/test.sh
+++ b/extras/kdf-keys/test.sh
@@ -42,8 +42,34 @@ check_white_spaces() {
 	done
 }
 
+check_password_len() {
+	hexsalt="73616c74"
+	iter=4096
+	keylen=20
+	./tomb-kdb-pbkdf2 $hexsalt $iter $keylen 2>/dev/null <<<"" && {
+        echo "Empty passwords are accepted"
+        error=$((error + 1))
+    }
+    boundpassword=`perl -e 'print "a"x1023'`
+    ./tomb-kdb-pbkdf2 $hexsalt $iter $keylen &>/dev/null <<<"$boundpassword" || {
+        echo "Passwords bound to limit are not accepted"
+        error=$((error + 1))
+    }
+    bigpassword=`perl -e 'print "a"x1024'`
+    ./tomb-kdb-pbkdf2 $hexsalt $iter $keylen &>/dev/null <<<"$bigpassword" && {
+        echo "Passwords overriding buffer are accepted"
+        error=$((error + 1))
+    }
+    bigpassword=`perl -e 'print "a"x1025'`
+    ./tomb-kdb-pbkdf2 $hexsalt $iter $keylen &>/dev/null <<<"$bigpassword" && {
+        echo "Passwords overriding buffer are accepted"
+        error=$((error + 1))
+    }
+}
+
 check_kdf
 check_white_spaces
+check_password_len
 
 if [[ $error == 1 ]]; then
 	exit $error

--- a/extras/kdf-keys/test.sh
+++ b/extras/kdf-keys/test.sh
@@ -47,24 +47,14 @@ check_password_len() {
 	iter=4096
 	keylen=20
 	./tomb-kdb-pbkdf2 $hexsalt $iter $keylen 2>/dev/null <<<"" && {
-        echo "Empty passwords are accepted"
-        error=$((error + 1))
-    }
-    boundpassword=`perl -e 'print "a"x1023'`
-    ./tomb-kdb-pbkdf2 $hexsalt $iter $keylen &>/dev/null <<<"$boundpassword" || {
-        echo "Passwords bound to limit are not accepted"
-        error=$((error + 1))
-    }
-    bigpassword=`perl -e 'print "a"x1024'`
-    ./tomb-kdb-pbkdf2 $hexsalt $iter $keylen &>/dev/null <<<"$bigpassword" && {
-        echo "Passwords overriding buffer are accepted"
-        error=$((error + 1))
-    }
-    bigpassword=`perl -e 'print "a"x1025'`
-    ./tomb-kdb-pbkdf2 $hexsalt $iter $keylen &>/dev/null <<<"$bigpassword" && {
-        echo "Passwords overriding buffer are accepted"
-        error=$((error + 1))
-    }
+		echo "Empty passwords are accepted"
+		error=$((error + 1))
+	}
+	bigpassword=`perl -e 'print "a"x3000'`
+	./tomb-kdb-pbkdf2 $hexsalt $iter $keylen &>/dev/null <<<"$bigpassword" || {
+		echo "Error when using long password"
+		error=$((error + 1))
+	}
 }
 
 check_kdf


### PR DESCRIPTION
Fixes this issue: https://github.com/dyne/Tomb/issues/307

There was also a test in `extras/kdf-keys` that was failing (it was assuming that the NULL byte could be part of the password), this PR makes the test to pass as well.

Some tests have been added checking that passwords are not split if they have whitespaces and checking len limits for passwords

It also enables the execution of tests in `extras/kd-keys` in travis' build