### PR TITLE
Fix mounted volume default path

### DIFF
--- a/extras/gtk-tray/tomb-gtk-tray.c
+++ b/extras/gtk-tray/tomb-gtk-tray.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
   }
 
   snprintf(filename,255, "%s", argv[1]);
-  snprintf(mountpoint,255, "/media/%s.tomb", argv[1]);
+  snprintf(mountpoint,255, "/media/%s", argv[1]);
 
   // libnotify
   notify_init("Tomb");


### PR DESCRIPTION
Default behavior for tomb is to mount the volume filename.tomb in /media/filename.

Ubuntu 16.04, Tomb 2.5