### PR TITLE
Add support for multiple GPG subkeys 

### DIFF
--- a/tomb
+++ b/tomb
@@ -1242,7 +1242,7 @@ gen_key() {
 			_warning "It is your responsibility to check these fingerprints."
 			_warning "The fingerprints are:"
 			for gpg_id in ${recipients[@]}; do
-				_warning "	  `_fingerprint "$gpg_id"`"
+				_warning "	  `_fingerprint "$gpg_id" ($gpg_id)`"
 			done
 
 			gpgopt+=(`_recipients_arg "$recipients_opt" $recipients`)
@@ -1322,7 +1322,7 @@ gen_key() {
 	local tmpres=$TOMBTMP
 	print $opt - "$gpgpass" \
 		| gpg --openpgp --force-mdc --cipher-algo ${algo} \
-			  --batch --no-tty ${gpgopt[@]} \
+			  --batch --no-tty ${gpgopt} \
 			  --status-fd 2 -o - --armor 2> $tmpres
 	unset gpgpass
 	# check result of gpg operation

--- a/tomb
+++ b/tomb
@@ -1242,7 +1242,7 @@ gen_key() {
 			_warning "It is your responsibility to check these fingerprints."
 			_warning "The fingerprints are:"
 			for gpg_id in ${recipients[@]}; do
-				_warning "	  `_fingerprint "$gpg_id" ($gpg_id)`"
+				_warning "	  `_fingerprint "$gpg_id"` ($gpg_id)"
 			done
 
 			gpgopt+=(`_recipients_arg "$recipients_opt" $recipients`)


### PR DESCRIPTION
When running (with patch applied):
tomb dig your.tomb -s 10
tomb forge your.tomb -k your.tomb.key -g -r **KEYID1!**,**KEYID2!**
(the ! is to tell gpg to use that specific subkey, not the one it likes)

We now get: (line 1245 in the patch)
<SNIP>
tomb [W] The fingerprints are:
tomb [W] **FINGERPRINT MASTERKEY ** (**KEYID1!**)
tomb [W] **FINGERPRINT MASTERKEY ** (**KEYID2!**)


And gpgopt contains (in the call on the patched line 1325): 
--encrypt --recipient **KEYID1!** --recipient **KEYID2!**

whereas without the patch ${gptopt[@]} is:
--encrypt

So it only uses the default key…


Note: The second commit is to correct a typo I made on line 1245 that included ($gpg_id) inside the call for _fingerprint, which obviously did nothing.