### PR TITLE
Update suggested command with missing flag

### DIFF
--- a/tomb
+++ b/tomb
@@ -1914,7 +1914,7 @@ lock_tomb_with_key() {
 
 	[[ -n $tombpath ]] || {
 		_warning "No tomb specified for locking."
-		_warning "Usage: tomb lock file.tomb file.tomb.key"
+		_warning "Usage: tomb lock file.tomb -k file.tomb.key"
 		return 1
 	}
 


### PR DESCRIPTION
`tomb lock` suggested command was missing "-k" flag; although this can be inferred from other commands, it's likely worth having it spelled out plainly