### PR TITLE
Use getent instead of directly parsing passwd

### DIFF
--- a/tomb
+++ b/tomb
@@ -245,7 +245,7 @@ _whoami() {
 	# }
 
 	# Force HOME to _USER's HOME if necessary
-	local home=$(awk -F: "/^$_USER:/ { print \$6 }" /etc/passwd 2>/dev/null)
+	local home=$(getent passwd "${_USER}" | cut -d: -f6)
 	[[ $home == $HOME ]] || {
 		_verbose "Updating HOME to match user's: ::1 home:: (was ::2 HOME::)" \
 				 $home $HOME


### PR DESCRIPTION
Hi. Please consider my patch.
When getting the home directory of the current user the file /etc/passwd was parsed instead of using getent like everywhere else.
When the current user is not local, for instance a ldap user, this causes the home directory to be guessed incorrectly. And because of that  bind-hooks execution is aborted.
Hope this helps.
Please tell if I have to make any adjustments.
Cheers!