### PR TITLE
Write all debug messages to stderr to avoid polluting stdout.

### DIFF
--- a/tomb
+++ b/tomb
@@ -820,6 +820,7 @@ function _msg() {
 			;;
 		verbose)
 			pchars="[D]"; pcolor="blue"
+			fd=2
 			;;
 		success)
 			pchars="(*)"; pcolor="green"


### PR DESCRIPTION
This code addresses issue #375 by forcing all verbose messages to write to STDERR.