### PR TITLE
Fix table syntax Markdown

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -163,7 +163,7 @@ Sure as Hell it can! Licensing issues aside ([GNU GPLv3+](COPYING)
 terms) Tomb provides machine-readable output and interaction via some
 flags:
 
-         flag   | function
+flag            | function
 --------------- | ------------------------------------------------
  --no-color     | avoids coloring output to allow parsing
  --unsafe       | allows passwords options and cleartext key from stdin


### PR DESCRIPTION
Fixed a visual error in `INSTALL.md`

The table was not showing properly.