### PR TITLE
Use _verbose for pinentry-curses in ask_password

### DIFF
--- a/tomb
+++ b/tomb
@@ -480,7 +480,7 @@ ask_password() {
 			if _is_found "pinentry-curses"; then
 				_verbose "using pinentry-curses"
 
-				_warning "Detected DISPLAY, but only pinentry-curses is found."
+				_verbose "Detected DISPLAY, but only pinentry-curses is found."
 				output=$(pinentry_assuan_getpass | pinentry-curses)
 			else
 				_failure "Cannot find any pinentry: impossible to ask for password."


### PR DESCRIPTION
Fixes https://github.com/dyne/Tomb/issues/385. Note that affected users will have to decrypt their existing tombs using the password `tomb [W] Detected DISPLAY, but only pinentry-curses is found.`.

Should I append KNOWN_BUGS in this PR, or would a maintainer like to write that part?