### PR TITLE
Read CFLAGS in kdf-keys makefile

### DIFF
--- a/extras/kdf-keys/Makefile
+++ b/extras/kdf-keys/Makefile
@@ -2,10 +2,10 @@
 PREFIX ?= /usr/local
 
 all:
-	$(CC) -O2 -o tomb-kdb-pbkdf2 pbkdf2.c -lgcrypt
-	$(CC) -O2 -o tomb-kdb-pbkdf2-getiter benchmark.c -lgcrypt
-	$(CC) -O2 -o tomb-kdb-pbkdf2-gensalt gen_salt.c -lgcrypt
-	$(CC) -O2 -o tomb-kdb-hexencode hexencode.c
+	$(CC) -O2 $(CFLAGS) -o tomb-kdb-pbkdf2 pbkdf2.c -lgcrypt
+	$(CC) -O2 $(CFLAGS) -o tomb-kdb-pbkdf2-getiter benchmark.c -lgcrypt
+	$(CC) -O2 $(CFLAGS) -o tomb-kdb-pbkdf2-gensalt gen_salt.c -lgcrypt
+	$(CC) -O2 $(CFLAGS) -o tomb-kdb-hexencode hexencode.c
 
 test:
 	@echo "Running Tomb-kdb tests"


### PR DESCRIPTION
Added `$(CFLAGS)` environment variable in the kdf-keys makefile to allow users to specify additional build flags.