### PR TITLE
Fix configs and dockerfile to enable sphinx in tests

### DIFF
--- a/extras/install_sphinx.sh
+++ b/extras/install_sphinx.sh
@@ -5,8 +5,11 @@ cd libsphinx
 git submodule update --init --recursive --remote
 cd src
 sed -i 's|/usr/local|/usr|' makefile
-make
-sudo make install
-ldconfig
-pip3 install pwdsphinx
-sudo mkdir -p /etc/sphinx
+make && make install && ldconfig
+cd ../..
+git clone https://github.com/stef/pwdsphinx
+cd pwdsphinx
+python3 setup.py install
+mkdir -p /etc/sphinx && cp ../test/sphinx.cfg /etc/sphinx/config && cd /etc/sphinx
+openssl req -new -x509 -nodes -out server.crt -keyout server.key -subj '/CN=localhost'
+sphinx init

--- a/extras/test/Dockerfile
+++ b/extras/test/Dockerfile
@@ -1,13 +1,15 @@
 FROM dyne/devuan:beowulf
 
-RUN apt-get update -y -q --allow-releaseinfo-change && apt-get install -y -q zsh cryptsetup gawk libgcrypt20-dev steghide qrencode python python2.7 python3-pip python3-dev libsodium-dev libssl-dev make gcc g++ sudo gettext file bsdmainutils
+RUN echo "deb http://deb.devuan.org/merged chimaera main" >> /etc/apt/sources.list
+RUN apt-get update -y -q --allow-releaseinfo-change
+RUN apt-get install -y -q -t beowulf zsh cryptsetup gawk libgcrypt20-dev steghide qrencode python python2.7 python3-pip python3-dev libssl-dev make gcc g++ sudo gettext file bsdmainutils
+RUN apt-get install -y -q -t chimaera libsodium23 libsodium-dev
 RUN pip3 install setuptools wheel
 
 COPY . /Tomb/
 
-# WORKDIR /Tomb/extras
-# RUN ./install_sphinx.sh
-# RUN cp test/sphinx.cfg /etc/sphinx/config
+WORKDIR /Tomb/extras
+RUN ./install_sphinx.sh
 
 WORKDIR /Tomb
 RUN make --directory=extras/kdf-keys

--- a/extras/test/sphinx.cfg
+++ b/extras/test/sphinx.cfg
@@ -3,6 +3,7 @@ verbose = False
 address = 127.0.0.1
 port = 2355
 datadir = /tmp/.sphinx/
+ssl_cert = /etc/sphinx/server.crt
 
 [server]
 verbose = False
@@ -10,7 +11,5 @@ address = 127.0.0.1
 port = 2355
 datadir = /tmp/.sphinx/
 keydir = /tmp/.sphinx/
-
-[websphinx]
-pinentry=/usr/bin/pinentry
-log=
+ssl_cert = /etc/sphinx/server.crt
+ssl_key = /etc/sphinx/server.key

--- a/tomb
+++ b/tomb
@@ -505,14 +505,14 @@ sphinx_set_password() {
 		# check first if this host/user combination exists in store
 		# if yes, there is no need to make a call to create
 		password=$(echo "$1" | sphinx get $(option_value --sphx-user) $(option_value --sphx-host) 2>$errorfile)
-		if  ! grep -q "ValueError: fail" $errorfile ; then
+		if  ! grep -q "error: sphinx protocol failure" $errorfile ; then
 			echo "$password"
 			rm $errorfile
 			return 0
 		fi
 		# no such host/user combination in store, create one
 		password=$(echo "$1" | sphinx create $(option_value --sphx-user) $(option_value --sphx-host) ulsd 0 2>$errorfile)
-		if  ! grep -q "ValueError: fail" $errorfile ; then
+		if  ! grep -q "error: sphinx protocol failure" $errorfile ; then
 			echo "$password"
 			rm $errorfile
 			return 0


### PR DESCRIPTION
- Installing **pwdsphinx** from pip3 still results in incorrect entrypoint, so now we're getting both **libsphinx** and **pwdsphinx** from the same place (more consistent)
- **sphinx** no longer _requires_ SSL cert, but fails without it (`check_hostname requires server_hostname`, seems like check_hostname in SSL context [stays True](https://github.com/stef/pwdsphinx/blob/0b2ae15ada58010469d9cb91c43aebf3ba9a893b/pwdsphinx/sphinx.py#L64) in that case); **oracle** requires it anyway so I kept the dummy cert creation in the sphinx installation script
- added chimaera repo to get the required version of libsodium (as I mentioned, compiling it from source takes a while)
- updated expected text for when sphinx command fails (it is no longer `ValueError: fail`)