### PR TITLE
lo_mount: check for loop support needs privilege escalation

### DIFF
--- a/tomb
+++ b/tomb
@@ -630,7 +630,7 @@ lo_mount() {
 	tpath="$1"
 
 	# check if we have support for loop mounting
-	TOMBLOOP=`losetup -f`
+	TOMBLOOP=`_sudo losetup -f`
 	[[ $? = 0 ]] || {
 		_warning "Loop mount of volumes is not possible on this machine, this error"
 		_warning "often occurs on VPS and kernels that don't provide the loop module."


### PR DESCRIPTION
If there is no free loop device, the call of loopsetup -f will create one and return it. For this it needs privilege escalation.
It doesn't need those, if there is already an used device, but that cannot be guaranteed.

Closes #436
________________
Just readds the logic before the change. Maybe there is a better way to check for loop support?