### PR TITLE
Update Dockerfile

### DIFF
--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -1,7 +1,7 @@
 ##
 # gregtzar/tomb
 #
-# This creates an Ubuntu derived base image and installs the tomb libarary
+# This creates an Ubuntu derived base image and installs the tomb library
 # along with it's dependencies.
 
 FROM dyne/devuan:chimaera
@@ -19,7 +19,7 @@ RUN apt-get update -y && \
 	zsh \
 	gnupg \
 	cryptsetup \
-	pinentry pinentry-curses \
+	pinentry-curses \
 	file xxd \
 	steghide \
 	mlocate \


### PR DESCRIPTION
Building the image fails as pinentry doesn't exist in the repository, only pinentry-curses. Image building works w/ only pinentry-curses.