### PR TITLE
fix typo Succesfully -> Successfully

### DIFF
--- a/extras/android/tomb
+++ b/extras/android/tomb
@@ -1647,7 +1647,7 @@ change_tomb_key() {
 
     _sudo cryptsetup luksClose "${mapper}" || _failure "Unexpected error in luksClose."
 
-    _success "Succesfully changed key for tomb: ::1 tomb file::" $TOMBFILE
+    _success "Successfully changed key for tomb: ::1 tomb file::" $TOMBFILE
     _message "The new key is: ::1 new key::" $TOMBKEYFILE
 
     return 0

--- a/extras/translations/de.po
+++ b/extras/translations/de.po
@@ -727,7 +727,7 @@ msgid "Unexpected error in luksClose."
 msgstr "Unerwarteter Fehler in luksClose."
 
 #: tomb:Create:change_tomb_key:1725
-msgid "Succesfully changed key for tomb: ::1 tomb file::"
+msgid "Successfully changed key for tomb: ::1 tomb file::"
 msgstr "Schlüssel erfolgreich gewechselt für das Grab: ::1 tomb file::"
 
 #: tomb:Create:change_tomb_key:1726

--- a/extras/translations/es.po
+++ b/extras/translations/es.po
@@ -704,7 +704,7 @@ msgid "Unexpected error in luksClose."
 msgstr "Error inesperado en luksClose."
 
 #: tomb:Create:change_tomb_key:1725
-msgid "Succesfully changed key for tomb: ::1 tomb file::"
+msgid "Successfully changed key for tomb: ::1 tomb file::"
 msgstr "Se ha cambiado la clave con éxito para la tumba ::1 tumba::"
 
 #: tomb:Create:change_tomb_key:1726

--- a/extras/translations/fr.po
+++ b/extras/translations/fr.po
@@ -781,7 +781,7 @@ msgid "Unexpected error in luksClose."
 msgstr "Une erreur inattendue s'est produite lors de luksClose."
 
 #: tomb:Create:change_tomb_key:1725
-msgid "Succesfully changed key for tomb: ::1 tomb file::"
+msgid "Successfully changed key for tomb: ::1 tomb file::"
 msgstr "La clé a été changée avec succès pour la tombe : ::1 tomb file::"
 
 #: tomb:Create:change_tomb_key:1726

--- a/extras/translations/it.po
+++ b/extras/translations/it.po
@@ -698,7 +698,7 @@ msgid "Unexpected error in luksClose."
 msgstr "Errore inaspettato in luksClose."
 
 #: tomb:Create:change_tomb_key:1725
-msgid "Succesfully changed key for tomb: ::1 tomb file::"
+msgid "Successfully changed key for tomb: ::1 tomb file::"
 msgstr "Cambiata con successo la key per il file tomb: ::1 tomb file::"
 
 #: tomb:Create:change_tomb_key:1726

--- a/extras/translations/ru.po
+++ b/extras/translations/ru.po
@@ -708,7 +708,7 @@ msgid "Unexpected error in luksClose."
 msgstr "Неожиданная ошибка в luksClose."
 
 #: tomb:Create:change_tomb_key:1725
-msgid "Succesfully changed key for tomb: ::1 tomb file::"
+msgid "Successfully changed key for tomb: ::1 tomb file::"
 msgstr "Ключ для гробницы ::1 tomb file:: успешно изменен"
 
 #: tomb:Create:change_tomb_key:1726

--- a/extras/translations/sv.po
+++ b/extras/translations/sv.po
@@ -705,7 +705,7 @@ msgid "Unexpected error in luksClose."
 msgstr "Oväntat fel i luksClose."
 
 #: tomb:Create:change_tomb_key:1725
-msgid "Succesfully changed key for tomb: ::1 tomb file::"
+msgid "Successfully changed key for tomb: ::1 tomb file::"
 msgstr "Nyckel ändrad för grav: ::1 tomb file::"
 
 #: tomb:Create:change_tomb_key:1726

--- a/extras/translations/tomb.pot
+++ b/extras/translations/tomb.pot
@@ -735,7 +735,7 @@ msgid "Unexpected error in luksClose."
 msgstr ""
 
 #: tomb:Create:change_tomb_key:1725
-msgid "Succesfully changed key for tomb: ::1 tomb file::"
+msgid "Successfully changed key for tomb: ::1 tomb file::"
 msgstr ""
 
 #: tomb:Create:change_tomb_key:1726

--- a/extras/translations/zh_Hans.po
+++ b/extras/translations/zh_Hans.po
@@ -733,7 +733,7 @@ msgid "Unexpected error in luksClose."
 msgstr ""
 
 #: tomb:Create:change_tomb_key:1725
-msgid "Succesfully changed key for tomb: ::1 tomb file::"
+msgid "Successfully changed key for tomb: ::1 tomb file::"
 msgstr ""
 
 #: tomb:Create:change_tomb_key:1726

--- a/tomb
+++ b/tomb
@@ -2236,7 +2236,7 @@ change_tomb_key() {
 
 	_sudo cryptsetup luksClose "${TOMBMAPPER}" || _failure "Unexpected error in luksClose."
 
-	_success "Succesfully changed key for tomb: ::1 tomb file::" $TOMBFILE
+	_success "Successfully changed key for tomb: ::1 tomb file::" $TOMBFILE
 	_message "The new key is: ::1 new key::" $TOMBKEYFILE
 
 	return 0


### PR DESCRIPTION
Just a little typo: `Succesfully` -> `Successfully`

Thank you for the great work!