### PR TITLE
cmd lock: extend parameters to --filesystem

### DIFF
--- a/doc/tomb.1
+++ b/doc/tomb.1
@@ -66,10 +66,21 @@ option can be used to specify the cipher specification: default is
 If you are looking for something exotic, also try
 "serpent-xts-plain64". More options may be found in cryptsetup(8) and
 Linux documentation. The \fI--filesystem\fR option can be used to
-specify "btrfs" as an alternative filesystem used to format the tomb,
+specify an alternative filesystem used to format the tomb,
 in place of the default "ext4". This operation requires root
-privileges to loopback mount, format the tomb (using LUKS and Ext4),
-then set the key in its first LUKS slot.
+privileges to loopback mount, format the tomb (using LUKS and mkfs),
+then set the key in its first LUKS slot. 
+
+.RS
+.nf
+Supported filesystems for \fI--filesystem\fR:
+"ext3"	using operating system defaults
+"ext4"	using operating system defaults
+"btrfs"	for tombs >= 47MB using operating system defaults
+"btrfsmixedmode"	for tombs >=18MB btrfs mixed mode (see mkfs.btrfs(8))
+"ext3maxinodes"	ext3 with a maximum of inodes (for many small files)
+"ext4maxinodes"	ext4 with a maximum of inodes (for many small files)
+.RE
 
 .B
 .IP "open"

--- a/tomb
+++ b/tomb
@@ -2078,9 +2078,22 @@ lock_tomb_with_key() {
 	local filesystem=ext4
     option_is_set --filesystem && {
 		filesystem=`option_value --filesystem`
+		local tombsize=`stat --format '%s' $tombpath`
 		case $filesystem in
 			ext3|ext4) ;;
-			btrfs) ;;
+			ext3maxinodes|ext4maxinodes) ;;
+			btrfs)
+				if [[ $tombsize < 49283072 ]]; then
+					_failure "Filesystem ::1 filesystem:: not supported on tombs smaller than 47MB." \
+						$filesystem
+				fi
+				;;
+			btrfsmixedmode)
+				if [[ $tombsize < 18874368 ]]; then
+					_failure "Filesystem ::1 filesystem:: not supported on tombs smaller than 18MB." \
+						$filesystem
+				fi
+				;;
 			*)
 				_failure "Filesystem not supported: ::1 filesystem::" $filesystem
 				return 1
@@ -2140,8 +2153,16 @@ lock_tomb_with_key() {
 		ext3|ext4)
 			_sudo mkfs.${filesystem} -q -F -j -L $TOMBNAME /dev/mapper/tomb.tmp
 			;;
+		ext3maxinodes|ext4maxinodes) # TODO: cover with test
+			filesystem=${filesystem:0:4}
+			_sudo mkfs.${filesystem} -q -F -j -i 1024 -b 1024 -L $TOMBNAME /dev/mapper/tomb.tmp
+			;;
 		btrfs) # TODO: cover with test
 			_sudo mkfs.${filesystem} -q -L $TOMBNAME /dev/mapper/tomb.tmp
+			;;
+		btrfsmixedmode) # TODO: cover with test
+			filesystem=${filesystem:0:5}
+			_sudo mkfs.${filesystem} -q -M -L $TOMBNAME /dev/mapper/tomb.tmp
 			;;
 	esac
 


### PR DESCRIPTION
The --filesystem option can be used  to  specify
an  alternative  filesystem used to format the tomb, in place of the default "ext4".

Beside "btrfs" now the following parameters to --filesystem are supported:

"ext3"    using operating system defaults
"ext4"    using operating system defaults
"btrfs"   for tombs >= 47MB using operating system defaults
"btrfsmixedmode"    for tombs >=18MB btrfs mixed mode (see mkfs.btrfs(8))
"ext3maxinodes"     ext3 with a maximum of inodes (for many small files)
"ext4maxinodes"     ext4 with a maximum of inodes (for many small files)

These changes help use scenarios in which there is a great number of small files and/or directories in a small filesystem, like e.g. the pass-tomb extension to pass.