### PR TITLE
Use $SUDO_ASKPASS if defined.  (allows GUI sudo password prompts)

### DIFF
--- a/tomb
+++ b/tomb
@@ -136,7 +136,8 @@ _sudo() {
 		local msg="[sudo] Enter password for user ::1 user:: to gain superuser privileges"
 		command -v gettext 1>/dev/null 2>/dev/null && msg="$(gettext -s "$msg")"
 		msg=${(S)msg//::1*::/$USER}
-		sudo -p "
+		[[ -n "$SUDO_ASKPASS" ]] && local sudo_askpass="--askpass"
+		sudo $sudo_askpass -p "
 $msg
 
 " ${@}


### PR DESCRIPTION
Use $SUDO_ASKPASS if defined.  Allows non-terminal sudo password prompts.
    
The sudo program checks this env var and uses it, but only if --askpass was given at the command line, or if it thinks there is no terminal. But the terminal detection is unreliable, so give it --askpass if there is an askpass program defined in the environment.

To try it, simply `export SUDO_ASKPASS=/usr/bin/ssh-askpass` before running tomb.

For me personally, this makes it possible to have a hotkey to run "pass" and "pass tomb" related commands.  Without this patch, invoking via hotkey causes my window manager to lock up while waiting for a password on the VT where Xorg was started... and since it's locked up, I can't change to the VT to enter the data it's waiting for.  So I have to log in via ssh from another host to recover it.

So, instead of locking up... now it can use a GUI askpass program.