### PR TITLE
Fix hexencode compilation warning caused by wrong type

### DIFF
--- a/extras/kdf-keys/hexencode.c
+++ b/extras/kdf-keys/hexencode.c
@@ -41,7 +41,7 @@ int main(int argc, char *argv[]) {
 	} else {
 		while( (read_bytes=fread(buf, sizeof(char), 2, stdin)) != 0) {
 			if(read_bytes == 1) buf[1]='\0';
-			sscanf(buf, "%x", &c);
+			sscanf(buf, "%s", &c);
 			printf("%c", c);
 		}
 		return 0;


### PR DESCRIPTION
I know `tomb-kdb-hexencode` was never used (as revealed in issue #471), but I recently compiled the kdf-keys and got this warning:

![hexencode](https://github.com/dyne/Tomb/assets/3987342/962bbc57-9804-4d4f-8476-7c57c4dad62d)

This PR change `%x` to `%s` as should be, as explained in [TutorialsPoint - C library function - sscanf()](https://www.tutorialspoint.com/c_standard_library/c_function_sscanf.htm). 

No need, i know. Just to keep things working.