### PR TITLE
Tomb accepts also plocate for search/index (not only mlocate)

### DIFF
--- a/tomb
+++ b/tomb
@@ -2813,13 +2813,13 @@ BEGIN { }
 # $1 is optional, to specify a tomb
 index_tombs() {
 	{ command -v updatedb 1>/dev/null 2>/dev/null } || {
-		_failure "Cannot index tombs on this system: updatedb (mlocate) not installed." }
+		_failure "Cannot index tombs on this system: updatedb (mlocate/plocate) not installed." }
 
 	updatedbver=`updatedb --version | grep '^updatedb'`
 	[[ "$updatedbver" =~ "GNU findutils" ]] && {
 		_warning "Cannot use GNU findutils for index/search commands." }
-	[[ "$updatedbver" =~ "mlocate" ]] || {
-		_failure "Index command needs 'mlocate' to be installed." }
+	[[ "$updatedbver" =~ "locate" ]] || {
+		_failure "Index command needs 'mlocate/plocate' to be installed." }
 
 	_verbose "$updatedbver"
 
@@ -2930,13 +2930,13 @@ EOF
 
 search_tombs() {
 	{ command -v locate 1>/dev/null 2>/dev/null } || {
-		_failure "Cannot index tombs on this system: updatedb (mlocate) not installed." }
+		_failure "Cannot index tombs on this system: updatedb (mlocate/plocate) not installed." }
 
 	updatedbver=`updatedb --version | grep '^updatedb'`
 	[[ "$updatedbver" =~ "GNU findutils" ]] && {
 		_warning "Cannot use GNU findutils for index/search commands." }
-	[[ "$updatedbver" =~ "mlocate" ]] || {
-		_failure "Index command needs 'mlocate' to be installed." }
+	[[ "$updatedbver" =~ "locate" ]] || {
+		_failure "Index command needs 'mlocate/plocate' to be installed." }
 
 	_verbose "$updatedbver"
 
@@ -2952,7 +2952,7 @@ search_tombs() {
 		tombname=${t[(ws:;:)5]}
 		tombmount="${t[(ws:;:)2]}"
 		[[ -r "${tombmount}/.updatedb" ]] && {
-			# Use mlocate to search hits on filenames
+			# Use mlocate/plocate to search hits on filenames
 			_message "Searching filenames in tomb ::1 tomb name::" $tombname
 			locate -d "${tombmount}/.updatedb" -e -i "${(f)@}"
 			_message "Matches found: ::1 matches::" \


### PR DESCRIPTION
### Related issue: #464

# The problem
Tomb is an old tool and uses `mlocate` for searching/indexing. But modern systems have replaced `mlocate` with `plocate`. On these systems (such as Linux Mint 21.1 and Ubuntu 22.04) the `tomb index` or `tomb search` commands are broken, user receives message:
```
Index command needs 'mlocate' to be installed.
```
To fix this issue i have changed lines with:
```
[[ "$updatedbver" =~ "mlocate" ]] || {
    _failure "Index command needs 'mlocate' to be installed." }
```
To:
```
[[ "$updatedbver" =~ "locate" ]] || {
    _failure "Index command needs 'mlocate/plocate' to be installed." }
```
Now both systems (with mlocate or plocate) works fine.

# Difference between mlocate and plocate
[plocate](https://plocate.sesse.net/) is backwards-compatible with mlocate, and is much faster and more efficient than mlocate.

In fact you don’t have a choice between mlocate and plocate in Ubuntu 22.04: if you install the former, you’ll end up with the latter anyway, because [mlocate is a transitional package](https://packages.ubuntu.com/jammy/mlocate) which pulls in [plocate](https://packages.ubuntu.com/jammy/plocate).

Source: [Difference between mlocate and plocate](https://unix.stackexchange.com/questions/727862/difference-between-mlocate-and-plocate)

