### PR TITLE
Translations severe update

### DIFF
--- a/extras/translations/Makefile
+++ b/extras/translations/Makefile
@@ -8,13 +8,14 @@ all:
 	@echo "Strings generated in tomb.pot"
 
 .PHONY: install
-install: es.mo ru.mo fr.mo de.mo sv.mo it.mo
-	install -Dm644 es.mo ${DESTDIR}${LOCALEDIR}/es_ES/${TOMBFILE}
-	install -Dm644 ru.mo ${DESTDIR}${LOCALEDIR}/ru_RU/${TOMBFILE}
-	install -Dm644 fr.mo ${DESTDIR}${LOCALEDIR}/fr_FR/${TOMBFILE}
+install: de.mo es.mo fr.mo it.mo pt_BR.mo ru.mo sv.mo
 	install -Dm644 de.mo ${DESTDIR}${LOCALEDIR}/de_DE/${TOMBFILE}
-	install -Dm644 sv.mo ${DESTDIR}${LOCALEDIR}/sv_SV/${TOMBFILE}
+	install -Dm644 es.mo ${DESTDIR}${LOCALEDIR}/es_ES/${TOMBFILE}
+	install -Dm644 fr.mo ${DESTDIR}${LOCALEDIR}/fr_FR/${TOMBFILE}
 	install -Dm644 it.mo ${DESTDIR}${LOCALEDIR}/it_IT/${TOMBFILE}
+	install -Dm644 pt_BR.mo ${DESTDIR}${LOCALEDIR}/pt_BR/${TOMBFILE}
+	install -Dm644 ru.mo ${DESTDIR}${LOCALEDIR}/ru_RU/${TOMBFILE}
+	install -Dm644 sv.mo ${DESTDIR}${LOCALEDIR}/sv_SV/${TOMBFILE}
 	@echo "Translations installed."
 
 %.mo: %.po

--- a/extras/translations/README.md
+++ b/extras/translations/README.md
@@ -1,0 +1,48 @@
+# TRANSLATIONS
+## 1. How to translate
+Tomb uses the [Weblate](https://hosted.weblate.org/projects/tomb/tomb/) platform to manage the translation efforts of it's user community.
+
+In Weblate, an user can click "Start new translation", choose a language and click "Request new translation". Additionally, just to reinforce your request, we recommend opening an [issue](https://github.com/dyne/Tomb/issues/new) requesting the development team to open a new translation for your language.
+
+## 2. About files in this folder
+All translation files in this folder (those with a ".po" extension) are based on the `tomb.pot` file.
+
+POT files are just templates and they don't contain any translations. To do a translation, create a new PO file based on the template.
+
+The `tomb.pot` template must be created using the perl script `generate_translatable_strings.pl` **for each new version of Tomb**:
+
+```sh
+$ perl generate_translatable_strings.pl > tomb.pot
+```
+
+After that, just open the `tomb.pot` file in the [poedit](https://poedit.net/) program, and click on "Start new translation" (bottom left button), select your language, save and start translating.
+
+## 3. Notes on versioning
+
+**As of June 27, 2023**, the current `tomb.pot` template was created on January 2, 2017 for `Tomb version 2.3`, which was released on the same date, as can be seen in [tag v2.3](https://github.com/dyne/Tomb/releases/tag/v2.3).
+
+```sh
+$ sed -n '9p' tomb.pot
+"PO-Revision-Date: Mon Jan  2 22:40:32 2017\n"
+```
+
+***Thus, all files in this folder, as of June 27, 2023, are valid for tomb version 2.3 `only`.***
+
+Old translations may work with recent versions of Tomb, but will be incomplete and wrong at many points.
+
+### 3.1 Exception
+Translation files for Brazilian Portuguese (pt_BR) was created in June 27, 2023. Precisely when it was noticed that the translations were out of date.
+
+So the translator created two versions: one for Tomb 2.3 (`pt_BR.pot` based upon `tomb.pot`) and another for Tomb 2.10 (`pt_BR-2.10.pot` based upon `tomb-2.10.pot`).
+
+For now it is the only updated translation for the current version of Tomb.
+
+## 4. Updating translation
+In your favorite shell, make a backup of old file adding it's version, then update with `msgmerge`:
+
+```sh
+$ cp lang.po lang-2.3.pot
+$ msgmerge --update lang.po tomb-2.10.pot
+```
+
+Open the new updated PO translation file and start reviewing the translation.

--- a/extras/translations/es.po
+++ b/extras/translations/es.po
@@ -1,15 +1,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Tomb the Crypto Undertaker\n"
-"PO-Revision-Date: 2022-04-04 10:06+0000\n"
-"Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2023-06-27 13:14-0300\n"
+"Last-Translator: Daniel Dias Rodrigues <danieldiasr@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/tomb/tomb/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12-dev\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #: tomb:Safety functions:_sudo:124
 msgid "[sudo] Enter password for user ::1 user:: to gain superuser privileges"
@@ -49,8 +50,7 @@ msgstr "Esto genera un riesgo en la seguridad."
 
 #: tomb:Safety functions:_ensure_safe_swap:333
 msgid "You can deactivate all swap partitions using the command:"
-msgstr ""
-"Puedes desactivar todas las particiones swap usando el siguiente instrucción:"
+msgstr "Puedes desactivar todas las particiones swap usando el siguiente instrucción:"
 
 #: tomb:Safety functions:_ensure_safe_swap:334
 msgid " swapoff -a"
@@ -126,8 +126,7 @@ msgstr "No es posible montar volúmenes en bucle en esta máquina, este error"
 
 #: tomb:Safety functions:lo_mount:571
 msgid "often occurs on VPS and kernels that don't provide the loop module."
-msgstr ""
-"ocurre frecuentemente en VPS y núcleos que no proporcionen el módulo 'loop'."
+msgstr "ocurre frecuentemente en VPS y núcleos que no proporcionen el módulo 'loop'."
 
 #: tomb:Safety functions:lo_mount:572
 msgid "It is impossible to use Tomb on this machine at this conditions."
@@ -147,7 +146,7 @@ msgstr " // Creación:"
 
 #: tomb:Commandline interaction:usage:618
 msgid " forge   create a new KEY file and set its password"
-msgstr " forge    crear un fichero LLAVE nuevo y fija su contraseña"
+msgstr " forge   crear un fichero LLAVE nuevo y fija su contraseña"
 
 #: tomb:Commandline interaction:usage:619
 msgid " lock    installs a lock on a TOMB to use it with KEY"
@@ -157,8 +156,7 @@ msgstr " lock    instala un candado en una TUMBA para usarlo con la LLAVE"
 msgid " // Operations on tombs:"
 msgstr " // Operaciones en tumbas:"
 
-#: tomb:Commandline
-#: interaction:usage:603
+#: tomb:Commandline interaction:usage:603
 msgid " open    open an existing TOMB"
 msgstr " open    abrir una TUMBA existente"
 
@@ -212,18 +210,17 @@ msgstr " // Esteganografía:"
 
 #: tomb:Commandline interaction:usage:643
 msgid " bury    hide a KEY inside a JPEG image (for use with -k)"
-msgstr " bury   esconde la LLAVE dentro de una imagen JPEG (para usarla con -k)"
+msgstr " bury    esconde la LLAVE dentro de una imagen JPEG (para usarla con -k)"
 
 #: tomb:Commandline interaction:usage:644
 msgid " exhume  extract a KEY from a JPEG image (prints to stdout)"
-msgstr " exhume extraer una LLAVE de una imagen JPEG (escribe en stdout)"
+msgstr " exhume  extraer una LLAVE de una imagen JPEG (escribe en stdout)"
 
 #: tomb:Commandline interaction:usage:647
 msgid "Options:"
 msgstr "Opciones:"
 
-#: tomb:Commandline
-#: interaction:usage:630
+#: tomb:Commandline interaction:usage:630
 msgid " -s     size of the tomb file when creating/resizing one (in MB)"
 msgstr " -s     tamaño de la tumba al crearla o cambiar su tamaño (en MB)"
 
@@ -237,7 +234,7 @@ msgstr " -n     no procesar los hooks encontrados en la tumba"
 
 #: tomb:Commandline interaction:usage:652
 msgid " -o     options passed to commands: open, lock, forge (see man)"
-msgstr " -o    opciones pasadas a instrucciones: abre, bloquea, forja (vea man)"
+msgstr " -o     opciones pasadas a instrucciones: abre, bloquea, forja (vea man)"
 
 #: tomb:Commandline interaction:usage:653
 msgid " -f     force operation (i.e. even if swap is active)"
@@ -973,9 +970,7 @@ msgstr "Por favor, especifica una tumba existente."
 
 #: tomb:Close:umount_tomb:2449
 msgid "Slamming tomb ::1 tomb name:: mounted on ::2 mount point::"
-msgstr ""
-"Cerrando de un portazo la tumba ::1 nombre:: montada en ::2 punto de "
-"montaje::"
+msgstr "Cerrando de un portazo la tumba ::1 nombre:: montada en ::2 punto de montaje::"
 
 #: tomb:Close:umount_tomb:2451
 msgid "Kill all processes busy inside the tomb."
@@ -1042,9 +1037,11 @@ msgid "Unrecognized option ::1 arg:: for subcommand ::2 subcommand::"
 msgstr "No se reconoce la opción ::1 argumento:: para el subcomando ::2 subcomando::"
 
 #: tomb:Main routine:main:2671
-msgid "You specified option ::1 option::, which is DANGEROUS and should only be used for testing\n"
+msgid ""
+"You specified option ::1 option::, which is DANGEROUS and should only be used for testing\n"
 "If you really want so, add --unsafe"
-msgstr "Has especificado la opción ::1 opción::, que es PELIGROSA y debería usarse sólo en testeo\n"
+msgstr ""
+"Has especificado la opción ::1 opción::, que es PELIGROSA y debería usarse sólo en testeo\n"
 "Si estás seguro, añade --unsafe"
 
 #: tomb:Main routine:main:2705
@@ -1161,13 +1158,11 @@ msgstr "formato del mapa bind-hooks: local/to/tomb local/to/$HOME"
 
 #: tomb:Open:exec_safe_bind_hooks:1948
 msgid "bind-hooks map format: local/to/tomb local/to/$HOME.  Rolling back"
-msgstr ""
-"Formato del mapa bind-hooks: local/para/tomb local/para/$HOME.  Retroceder"
+msgstr "Formato del mapa bind-hooks: local/para/tomb local/para/$HOME.  Retroceder"
 
 #: tomb:Resize:resize_tomb:2323
 msgid "Commanded to resize tomb ::1 tomb name:: to ::2 size:: mebibytes."
-msgstr ""
-"Instruido para redimensionar tumba ::1 tumba name:: a ::2 tamaño:: mebibytes."
+msgstr "Instruido para redimensionar tumba ::1 tumba name:: a ::2 tamaño:: mebibytes."
 
 #: tomb:Resize:resize_tomb:2367
 msgid "Tomb seems resized already, operating filesystem stretch"

--- a/extras/translations/fr.po
+++ b/extras/translations/fr.po
@@ -1,15 +1,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Tomb the Crypto Undertaker\n"
-"PO-Revision-Date: 2022-06-27 13:20+0000\n"
-"Last-Translator: Alex <alexandre@pujol.io>\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2023-06-27 13:11-0300\n"
+"Last-Translator: Daniel Dias Rodrigues <danieldiasr@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/tomb/tomb/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.13.1-dev\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #: tomb:Safety functions:_sudo:124
 msgid "[sudo] Enter password for user ::1 user:: to gain superuser privileges"
@@ -154,15 +155,15 @@ msgstr ""
 
 #: tomb:Commandline interaction:usage:612
 msgid "Syntax: tomb [options] command [arguments]"
-msgstr "Syntaxe : tomb [options] commande [arguments]"
+msgstr "Syntaxe: tomb [options] commande [arguments]"
 
 #: tomb:Commandline interaction:usage:614
 msgid "Commands:"
-msgstr "Commandes :"
+msgstr "Commandes:"
 
 #: tomb:Commandline interaction:usage:616
 msgid " // Creation:"
-msgstr " // Création :"
+msgstr " // Création:"
 
 #: tomb:Commandline interaction:usage:618
 msgid " forge   create a new KEY file and set its password"
@@ -176,7 +177,7 @@ msgstr " lock    (vérouiller)    Vérouiller une TOMBE avec une CLÉ"
 
 #: tomb:Commandline interaction:usage:621
 msgid " // Operations on tombs:"
-msgstr " // Opérations sur les tombes :"
+msgstr " // Opérations sur les tombes:"
 
 #: tomb:Commandline interaction:usage:603
 msgid " open    open an existing TOMB"
@@ -207,8 +208,8 @@ msgstr ""
 #: tomb:Commandline interaction:usage:627
 msgid " slam    slam a TOMB killing all programs using it"
 msgstr ""
-" slam           Referme une tombe brutalement, tuant tous les programmes qui "
-"l'utilisent"
+" slam    (claquer)       Referme une tombe brutalement, tuant tous les "
+"programmes qui l'utilisent"
 
 #: tomb:Commandline interaction:usage:629
 msgid " resize  resize a TOMB to a new size -s (can only grow)"
@@ -216,7 +217,7 @@ msgstr " resize  (élargir)       Augmenter la taille d'une TOMBE à -s Mo"
 
 #: tomb:Commandline interaction:usage:632
 msgid " // Operations on keys:"
-msgstr " // Opération sur les clés :"
+msgstr " // Opération sur les clés:"
 
 #: tomb:Commandline interaction:usage:633
 msgid " passwd  change the password of a KEY (needs old pass)"
@@ -231,7 +232,7 @@ msgstr ""
 
 #: tomb:Commandline interaction:usage:637
 msgid " // Backup on paper:"
-msgstr " // Sauvegarde sur papier :"
+msgstr " // Sauvegarde sur papier:"
 
 #: tomb:Commandline interaction:usage:638
 msgid " engrave makes a QR code of a KEY to be saved on paper"
@@ -241,19 +242,23 @@ msgstr ""
 
 #: tomb:Commandline interaction:usage:642
 msgid " // Steganography:"
-msgstr " // Stéganographie :"
+msgstr " // Stéganographie:"
 
 #: tomb:Commandline interaction:usage:643
 msgid " bury    hide a KEY inside a JPEG image (for use with -k)"
-msgstr " bury    Cache une CLÉ dans une image JPEG (utilisable avec -k)"
+msgstr ""
+" bury    (enterrer)      Cache une CLÉ dans une image JPEG (utilisable avec -"
+"k)"
 
 #: tomb:Commandline interaction:usage:644
 msgid " exhume  extract a KEY from a JPEG image (prints to stdout)"
-msgstr " exhume  Extraire une CLÉ d'une image JPEG (affiché sur stdout)"
+msgstr ""
+" exhume  (exhumer)       Extraire une CLÉ d'une image JPEG (affiché sur "
+"stdout)"
 
 #: tomb:Commandline interaction:usage:647
 msgid "Options:"
-msgstr "Options :"
+msgstr "Options:"
 
 #: tomb:Commandline interaction:usage:630
 msgid " -s     size of the tomb file when creating/resizing one (in MB)"
@@ -1170,8 +1175,8 @@ msgstr ""
 msgid ""
 "The create command is deprecated, please use dig, forge and lock instead."
 msgstr ""
-"La commande \"create\" est obsolète : il convient à présent d'utiliser \"dig"
-"\", \"forge\", et \"lock\"."
+"La commande \"create\" est obsolète : il convient à présent d'utiliser "
+"\"dig\", \"forge\", et \"lock\"."
 
 #: tomb:Main routine:main:2706
 msgid "For more informations see Tomb's manual page (man tomb)."

--- a/extras/translations/it.po
+++ b/extras/translations/it.po
@@ -1,11 +1,15 @@
 msgid ""
 msgstr ""
+"Project-Id-Version: Tomb\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Daniel Dias Rodrigues <danieldiasr@gmail.com>\n"
+"Language-Team: \n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: POEditor.com\n"
-"Project-Id-Version: Tomb\n"
-"Language: it\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #: tomb:Safety functions:_sudo:124
 msgid "[sudo] Enter password for user ::1 user:: to gain superuser privileges"
@@ -49,7 +53,7 @@ msgstr "Puoi disattivare tutte le partizioni di swap usando il comando:"
 
 #: tomb:Safety functions:_ensure_safe_swap:334
 msgid " swapoff -a"
-msgstr "␣swapoff -a"
+msgstr " swapoff -a"
 
 #: tomb:Safety functions:_ensure_safe_swap:336
 msgid "But if you want to proceed like this, use the -f (force) flag."
@@ -141,64 +145,63 @@ msgstr " // Creazione:"
 
 #: tomb:Commandline interaction:usage:618
 msgid " forge   create a new KEY file and set its password"
-msgstr "␣forge   crea un nuovo KEY file e imposta la sua password "
+msgstr " forge   crea un nuovo KEY file e imposta la sua password "
 
 #: tomb:Commandline interaction:usage:619
 msgid " lock    installs a lock on a TOMB to use it with KEY"
-msgstr "␣lock    installa un codice di blocco su un file TOMB da usare con la sua KEY "
+msgstr " lock    installa un codice di blocco su un file TOMB da usare con la sua KEY "
 
 #: tomb:Commandline interaction:usage:621
 msgid " // Operations on tombs:"
-msgstr "␣// Operazioni sui file tomb: "
+msgstr " // Operazioni sui file tomb: "
 
-#: tomb:Commandline
-#: interaction:usage:603
+#: tomb:Commandline interaction:usage:603
 msgid " open    open an existing TOMB"
-msgstr "␣open    apri un file esistente TOMB"
+msgstr " open    apri un file esistente TOMB"
 
 #: tomb:Commandline interaction:usage:623
 msgid " index   update the search indexes of tombs"
-msgstr "␣index  aggiorna gli indici di ricerca dei file tomb"
+msgstr " index   aggiorna gli indici di ricerca dei file tomb"
 
 #: tomb:Commandline interaction:usage:624
 msgid " search  looks for filenames matching text patterns"
-msgstr "␣search  cerca i nomi di file che soddisfano i parametri richiesti"
+msgstr " search  cerca i nomi di file che soddisfano i parametri richiesti"
 
 #: tomb:Commandline interaction:usage:625
 msgid " list    list of open TOMBs and information on them"
-msgstr "␣list    lista dei file TOMB aperti e informazioni su di essi"
+msgstr " list    lista dei file TOMB aperti e informazioni su di essi"
 
 #: tomb:Commandline interaction:usage:626
 msgid " close   close a specific TOMB (or 'all')"
-msgstr "␣close   chiude uno specifico file TOMB (oppure 'all' per chiuderli tutti)"
+msgstr " close   chiude uno specifico file TOMB (oppure 'all' per chiuderli tutti)"
 
 #: tomb:Commandline interaction:usage:627
 msgid " slam    slam a TOMB killing all programs using it"
-msgstr "␣slam    per chiudere in fretta un file TOMB uccidendo tutti i programmi che lo utilizzano"
+msgstr " slam    per chiudere in fretta un file TOMB uccidendo tutti i programmi che lo utilizzano"
 
 #: tomb:Commandline interaction:usage:629
 msgid " resize  resize a TOMB to a new size -s (can only grow)"
-msgstr "␣resize  ingrandilre un file TOMB in una nuova grandezza -s (solo espansione)"
+msgstr " resize  ingrandilre un file TOMB in una nuova grandezza -s (solo espansione)"
 
 #: tomb:Commandline interaction:usage:632
 msgid " // Operations on keys:"
-msgstr "␣// Operazioni sulle chiavi:"
+msgstr " // Operazioni sulle chiavi:"
 
 #: tomb:Commandline interaction:usage:633
 msgid " passwd  change the password of a KEY (needs old pass)"
-msgstr "␣passwd  cambiare la password di una KEY (necessaria la vecchia password) "
+msgstr " passwd  cambiare la password di una KEY (necessaria la vecchia password) "
 
 #: tomb:Commandline interaction:usage:634
 msgid " setkey  change the KEY locking a TOMB (needs old key and pass)"
-msgstr "␣setkey  cambia la KEY che blocca un file TOMB (necessaria la vecchia key e password)"
+msgstr " setkey  cambia la KEY che blocca un file TOMB (necessaria la vecchia key e password)"
 
 #: tomb:Commandline interaction:usage:637
 msgid " // Backup on paper:"
-msgstr "␣// Backup 'su carta':"
+msgstr " // Backup 'su carta':"
 
 #: tomb:Commandline interaction:usage:638
 msgid " engrave makes a QR code of a KEY to be saved on paper"
-msgstr "␣engrave crea un QR CODe di una KEY da stampare su carta"
+msgstr " engrave crea un QR CODe di una KEY da stampare su carta"
 
 #: tomb:Commandline interaction:usage:642
 msgid " // Steganography:"
@@ -206,56 +209,55 @@ msgstr " // Steganografia:"
 
 #: tomb:Commandline interaction:usage:643
 msgid " bury    hide a KEY inside a JPEG image (for use with -k)"
-msgstr "␣bury    nasconde una KEY dentro un'immagine JPEG (da usare con switch -k)"
+msgstr " bury    nasconde una KEY dentro un'immagine JPEG (da usare con switch -k)"
 
 #: tomb:Commandline interaction:usage:644
 msgid " exhume  extract a KEY from a JPEG image (prints to stdout)"
-msgstr "␣exhume  estrae una KEY da un'immagine JPEG (viene visualizzata a video) "
+msgstr " exhume  estrae una KEY da un'immagine JPEG (viene visualizzata a video) "
 
 #: tomb:Commandline interaction:usage:647
 msgid "Options:"
 msgstr "Opzioni:"
 
-#: tomb:Commandline
-#: interaction:usage:630
+#: tomb:Commandline interaction:usage:630
 msgid " -s     size of the tomb file when creating/resizing one (in MB)"
-msgstr "␣-s     misura del file tomb in creazione/espansione (in MB)"
+msgstr " -s     misura del file tomb in creazione/espansione (in MB)"
 
 #: tomb:Commandline interaction:usage:650
 msgid " -k     path to the key to be used ('-k -' to read from stdin)"
-msgstr "␣-k     percorso alla key da utilizzare ('-k -' per leggerla dallo standard input)"
+msgstr " -k     percorso alla key da utilizzare ('-k -' per leggerla dallo standard input)"
 
 #: tomb:Commandline interaction:usage:651
 msgid " -n     don't process the hooks found in tomb"
-msgstr "␣-n     non elaborare i collegamenti trovati in tomb"
+msgstr " -n     non elaborare i collegamenti trovati in tomb"
 
 #: tomb:Commandline interaction:usage:652
 msgid " -o     options passed to commands: open, lock, forge (see man)"
-msgstr "␣-o     opzioni passate ai comandi: open, lock, forge (vedi man page)"
+msgstr " -o     opzioni passate ai comandi: open, lock, forge (vedi man page)"
 
 #: tomb:Commandline interaction:usage:653
 msgid " -f     force operation (i.e. even if swap is active)"
-msgstr "␣-f     forza l'operazione (es. anche se lo swap è attivo)"
+msgstr " -f     forza l'operazione (es. anche se lo swap è attivo)"
 
 #: tomb:Commandline interaction:usage:655
 msgid " --kdf  forge keys armored against dictionary attacks"
-msgstr "␣--kdf  forgia chiavi corazzate contro gli attacchi con dizionari"
+msgstr " --kdf  forgia chiavi corazzate contro gli attacchi con dizionari"
 
 #: tomb:Commandline interaction:usage:659
 msgid " -h     print this help"
-msgstr "␣-h     stampa questo file di aiuto"
+msgstr " -h     stampa questo file di aiuto"
 
 #: tomb:Commandline interaction:usage:660
 msgid " -v     print version, license and list of available ciphers"
-msgstr "␣-v     stampa versione, licenza, e lista dei tipi di cifratura disponibili"
+msgstr " -v     stampa versione, licenza, e lista dei tipi di cifratura disponibili"
 
 #: tomb:Commandline interaction:usage:661
 msgid " -q     run quietly without printing informations"
-msgstr "␣-q     esegue le operazioni senza stampare nulla a video"
+msgstr " -q     esegue le operazioni senza stampare nulla a video"
 
 #: tomb:Commandline interaction:usage:662
 msgid " -D     print debugging information at runtime"
-msgstr "␣-D     mostra le informazioni di debug/runtime"
+msgstr " -D     mostra le informazioni di debug/runtime"
 
 #: tomb:Commandline interaction:usage:664
 msgid "For more informations on Tomb read the manual: man tomb"
@@ -303,7 +305,7 @@ msgstr "Questa operazione richiede di specificare un file chiave usando l'opzion
 
 #: tomb:Key operations:_load_key:894
 msgid "Waiting for the key to be piped from stdin... "
-msgstr "Attendo la key dal pipe di stdin....␣"
+msgstr "Attendo la key dal pipe di stdin.... "
 
 #: tomb:Key operations:_load_key:905
 msgid "Key not found, specify one using -k."
@@ -1034,9 +1036,11 @@ msgid "Unrecognized option ::1 arg:: for subcommand ::2 subcommand::"
 msgstr "Opzione sconosciuta ::1 arg:: per il sotto-comando ::2 subcommand::"
 
 #: tomb:Main routine:main:2671
-msgid "You specified option ::1 option::, which is DANGEROUS and should only be used for testing\n"
+msgid ""
+"You specified option ::1 option::, which is DANGEROUS and should only be used for testing\n"
 "If you really want so, add --unsafe"
-msgstr "Hai specificato l'opzione ::1 option::, che è PERICOLOSA e dovrebbe essere usata solo per test.\n"
+msgstr ""
+"Hai specificato l'opzione ::1 option::, che è PERICOLOSA e dovrebbe essere usata solo per test.\n"
 "Se vuoi veramente farlo, aggiungi lo switch --unsafe"
 
 #: tomb:Main routine:main:2705
@@ -1069,11 +1073,11 @@ msgstr "Tomb ::1 version:: - un forte e gentile becchino per i tuoi segreti"
 
 #: tomb:Main routine:main:2807
 msgid " This is free software: you are free to change and redistribute it"
-msgstr "␣Questo è free software: sei libero di modificarlo e ridistribuirlo"
+msgstr " Questo è free software: sei libero di modificarlo e ridistribuirlo"
 
 #: tomb:Main routine:main:2808
 msgid " For the latest sourcecode go to <http://dyne.org/software/tomb>"
-msgstr "␣Per i sorgenti aggiornati vai al sito <http://dyne.org/software/tomb>"
+msgstr " Per i sorgenti aggiornati vai al sito <http://dyne.org/software/tomb>"
 
 #: tomb:Main routine:main:2813
 msgid " This source code is distributed in the hope that it will be useful,"
@@ -1125,7 +1129,7 @@ msgstr ""
 
 #: tomb:Commandline interaction:usage:649
 msgid " -s     size of the tomb file when creating/resizing one (in MiB)"
-msgstr "␣-s     misura del file tomb in creazione/espansione (in MiB)"
+msgstr " -s     misura del file tomb in creazione/espansione (in MiB)"
 
 #: tomb:Key operations:get_lukskey:988
 msgid "Unlocking KDF key protection (::1 kdf::)"
@@ -1170,4 +1174,3 @@ msgstr ""
 #: tomb:Main routine:main:2806
 msgid " Copyright (C) 2007-2017 Dyne.org Foundation, License GNU GPL v3+"
 msgstr " Copyright (C) 2007-2017 Dyne.org Foundation, License GNU GPL v3+"
-

--- a/extras/translations/pt_BR-2.10.po
+++ b/extras/translations/pt_BR-2.10.po
@@ -1,0 +1,1547 @@
+# Tomb - The Crypto Undertaker.
+# Copyright (C) 2007-2014 Dyne.org Foundation
+# Denis Roio <jaromil@dyne.org>, 2013.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: Tue Jun 27 15:23:46 2023\n"
+"PO-Revision-Date: 2023-06-27 15:35-0300\n"
+"Last-Translator: Daniel Dias Rodrigues <danieldiasr@gmail.com>\n"
+"Language-Team: Tomb developers <crypto@lists.dyne.org>\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#: tomb:Safety functions:_sudo:120
+msgid "$pescmd executable not found"
+msgstr "executável $pescmd não encontrado"
+
+#: tomb:Safety functions:_sudo:124
+msgid "[sudo] Enter password for user ::1 user:: to gain superuser privileges"
+msgstr ""
+"[sudo] Digite a senha do usuário ::1 usuário:: para obter privilégios de "
+"superusuário"
+
+#: tomb:Safety functions:_sudo:131
+msgid "Super user execution not supported: ::1 sudo::"
+msgstr "Execução de superusuário não suportada: ::1 sudo::"
+
+#: tomb:Safety functions:_whoami:236
+msgid "Failing to identify the user who is calling us"
+msgstr "Falha ao identificar o usuário que está nos chamando"
+
+#: tomb:Safety functions:_tmp_create:272
+msgid "Fatal error creating the temporary directory: ::1 temp dir::"
+msgstr "Erro fatal ao criar o diretório temporário: ::1 diretório temporário::"
+
+#: tomb:Safety functions:_tmp_create:280
+msgid "Fatal error setting the permission umask for temporary files"
+msgstr "Erro fatal ao definir a permissão umask para arquivos temporários"
+
+#: tomb:Safety functions:_tmp_create:283
+msgid "Someone is messing up with us trying to hijack temporary files."
+msgstr ""
+"Alguém está nos atrapalhando tentando sequestrar arquivos temporários "
+"(\"hijack\")."
+
+#: tomb:Safety functions:_tmp_create:287
+msgid "Fatal error creating a temporary file: ::1 temp file::"
+msgstr "Erro fatal ao criar um arquivo temporário: ::1 arquivo temporário::"
+
+#: tomb:Safety functions:_ensure_safe_swap:398
+msgid "An active swap partition is detected..."
+msgstr "Foi detectada uma partição swap ativa..."
+
+#: tomb:Safety functions:_ensure_safe_swap:408
+msgid "Found zramswap with writeback enabled."
+msgstr "Encontrado zramswap com writeback ativado."
+
+#: tomb:Safety functions:_ensure_safe_swap:411
+msgid "Found zramswap without writeback to disk."
+msgstr "Encontrado zramswap sem writeback no disco."
+
+#: tomb:Safety functions:_ensure_safe_swap:424
+msgid "The undertaker found that all swap partitions are encrypted. Good."
+msgstr ""
+"O agente funerário descobriu que todas as partições swap são criptografadas. "
+"Bom."
+
+#: tomb:Safety functions:_ensure_safe_swap:426
+msgid "This poses a security risk."
+msgstr "Isso representa um risco de segurança."
+
+#: tomb:Safety functions:_ensure_safe_swap:427
+msgid "You can deactivate all swap partitions using the command:"
+msgstr "Você pode desativar todas as partições swap usando o comando:"
+
+#: tomb:Safety functions:_ensure_safe_swap:428
+msgid " swapoff -a"
+msgstr " swapoff -a"
+
+#: tomb:Safety functions:_ensure_safe_swap:429
+msgid "[#163] I may not detect plain swaps on an encrypted volume."
+msgstr "[#163] Posso não detectar swaps simples em um volume criptografado."
+
+#: tomb:Safety functions:_ensure_safe_swap:430
+msgid "But if you want to proceed like this, use the -f (force) flag."
+msgstr "Mas se quiser prosseguir desse modo, use o sinalizador -f (forçar)."
+
+#: tomb:Safety functions:_check_swap:449
+msgid "Operation aborted."
+msgstr "Operação abortada."
+
+#: tomb:Safety functions:ask_password:536
+msgid "Cannot find any pinentry-curses and no DISPLAY detected."
+msgstr ""
+"Não foi possível encontrar qualquer pinentry-curses e nenhum DISPLAY foi "
+"detectado."
+
+#: tomb:Safety functions:ask_password:550
+msgid "Pinentry error: ::1 error::"
+msgstr "Erro pinentry: ::1 erro::"
+
+#: tomb:Safety functions:ask_password:562
+msgid "Empty password"
+msgstr "Senha vazia"
+
+#: tomb:Safety functions:sphinx_get_password:587
+msgid "sphinx returns error: ::1 error::"
+msgstr "sphinx retornou um erro: ::1 erro::"
+
+#: tomb:Safety functions:sphinx_get_password:589
+msgid "Failed to retrieve actual password with sphinx."
+msgstr "Falha ao recuperar a senha real com sphinx."
+
+#: tomb:Safety functions:sphinx_get_password:592
+msgid "Both host and user have to be set to use sphinx"
+msgstr ""
+"Tanto o host quanto o usuário devem ser configurados para usar o sphinx"
+
+#: tomb:Safety functions:sphinx_set_password:623
+msgid "Failed to create password with sphinx"
+msgstr "Falha ao criar senha com sphinx"
+
+#: tomb:Safety functions:is_valid_tomb:636
+msgid "Tomb file is missing from arguments."
+msgstr "Está faltando nos argumentos o arquivo de tumba."
+
+#: tomb:Safety functions:is_valid_tomb:643
+msgid "Tomb file is not writable: ::1 tomb file::"
+msgstr "O arquivo de tumba não é gravável: ::1 arquivo tumba::"
+
+#: tomb:Safety functions:is_valid_tomb:650
+msgid "Tomb file is not a regular file: ::1 tomb file::"
+msgstr "O arquivo de tumba não é um arquivo regular: ::1 arquivo tumba::"
+
+#: tomb:Safety functions:is_valid_tomb:656
+msgid "Tomb file is empty (zero length): ::1 tomb file::"
+msgstr "O arquivo de tumba está vazio (comprimento zero): ::1 arquivo tumba::"
+
+#: tomb:Safety functions:is_valid_tomb:662
+msgid "Tomb command failed: ::1 command name::"
+msgstr "Comando Tomb falhou: ::1 nome do comando::"
+
+#: tomb:Safety functions:is_valid_tomb:667
+msgid "File is not yet a tomb: ::1 tomb file::"
+msgstr "O arquivo ainda não é uma tumba: ::1 arquivo tumba::"
+
+#: tomb:Safety functions:is_valid_tomb:687
+msgid "Tomb won't work without a TOMBNAME."
+msgstr "Tomb não funcionará sem uma TOMBNAME."
+
+#: tomb:Safety functions:is_valid_tomb:698
+msgid "Tomb file already in use: ::1 tombname::"
+msgstr "A tumba está atualmente em uso: ::1 nome da tumba::"
+
+#: tomb:Safety functions:is_valid_tomb:704
+msgid "Valid tomb file found: ::1 tomb path::"
+msgstr "Encontrado arquivo de tumba válido: ::1 caminho da tumba::"
+
+#: tomb:Safety functions:lo_mount:716
+msgid "Loop mount of volumes is not possible on this machine, this error"
+msgstr "A montagem em loop de volumes não é possível nesta máquina, este erro"
+
+#: tomb:Safety functions:lo_mount:717
+msgid "often occurs on VPS and kernels that don't provide the loop module."
+msgstr "geralmente ocorre em VPS e kernels que não fornecem o módulo de loop."
+
+#: tomb:Safety functions:lo_mount:718
+msgid "It is impossible to use Tomb on this machine under these conditions."
+msgstr "É impossível usar Tomb nesta máquina nestas condições."
+
+#: tomb:Safety functions:lo_mount:726
+msgid "Loopback mount failed: ::1 path:: on ::2 loop::"
+msgstr "Falha na montagem de loopback: ::1 caminho:: em ::2 loop::"
+
+#: tomb:Commandline interaction:usage:762
+msgid "Syntax: tomb [options] command [arguments]"
+msgstr "Sintaxe: tomb [opções] comando [argumentos]"
+
+#: tomb:Commandline interaction:usage:764
+msgid "Commands:"
+msgstr "Comandos:"
+
+#: tomb:Commandline interaction:usage:766
+msgid " // Creation:"
+msgstr " // Criação:"
+
+#: tomb:Commandline interaction:usage:767
+msgid " dig          create a new empty TOMB file of size -s in MiB"
+msgstr " dig          cria um novo arquivo de TUMBA vazio de tamanho -s em MiB"
+
+#: tomb:Commandline interaction:usage:768
+msgid " forge        create a new KEY file and set its password"
+msgstr " forge        cria um novo arquivo de CHAVE e define sua senha"
+
+#: tomb:Commandline interaction:usage:769
+msgid " lock         installs a lock on a TOMB to use it with KEY"
+msgstr ""
+" lock         instala um cadeado em uma TUMBA para usá-lo com uma CHAVE"
+
+#: tomb:Commandline interaction:usage:771
+msgid " // Operations on tombs:"
+msgstr " // Operações sobre tumbas:"
+
+#: tomb:Commandline interaction:usage:772
+msgid " open         open an existing TOMB (-k KEY file or - for stdin)"
+msgstr ""
+" open         abre uma TUMBA existente (-k arquivo de CHAVE ou - para stdin)"
+
+#: tomb:Commandline interaction:usage:773
+msgid " index        update the search indexes of tombs"
+msgstr " index        atualiza os índices de busca de tumbas"
+
+#: tomb:Commandline interaction:usage:774
+msgid " search       looks for filenames matching text patterns"
+msgstr ""
+" search       procura nomes de arquivos com padrões de texto correspondentes"
+
+#: tomb:Commandline interaction:usage:775
+msgid " list         list of open TOMBs and information on them"
+msgstr " list         lista TUMBAS abertas e informações sobre elas"
+
+#: tomb:Commandline interaction:usage:776
+msgid " ps           list of running processes inside open TOMBs"
+msgstr " ps           lista processos em execução dentro de TUMBAS abertas"
+
+#: tomb:Commandline interaction:usage:777
+msgid " close        close a specific TOMB (or 'all')"
+msgstr " close        fecha uma TUMBA específica (ou todas: 'all')"
+
+#: tomb:Commandline interaction:usage:778
+msgid " slam         slam a TOMB killing all programs using it"
+msgstr ""
+" slam         fecha uma TUMBA matando todos os programas que a estejam usando"
+
+#: tomb:Commandline interaction:usage:780
+msgid " resize       resize a TOMB to a new size -s (can only grow)"
+msgstr ""
+" resize       redimensiona uma TUMBA para o novo tamanho -s (só pode "
+"aumentar)"
+
+#: tomb:Commandline interaction:usage:783
+msgid " // Operations on keys:"
+msgstr " // Operações sobre chaves:"
+
+#: tomb:Commandline interaction:usage:784
+msgid " passwd       change the password of a KEY (needs old pass)"
+msgstr " passwd       altera a senha de uma CHAVE (a antiga é necessária)"
+
+#: tomb:Commandline interaction:usage:785
+msgid " setkey       change the KEY locking a TOMB (needs old key and pass)"
+msgstr ""
+" setkey       altera a CHAVE de uma TUMBA (precisa da chave e senha antigas)"
+
+#: tomb:Commandline interaction:usage:788
+msgid " // Backup on paper:"
+msgstr " // Backup em papel:"
+
+#: tomb:Commandline interaction:usage:789
+msgid " engrave      makes a QR code of a KEY to be saved on paper"
+msgstr " engrave      cria um QR code de uma CHAVE para ser salvo em papel"
+
+#: tomb:Commandline interaction:usage:793
+msgid " // Steganography:"
+msgstr " // Esteganografia:"
+
+#: tomb:Commandline interaction:usage:795
+msgid " bury         hide a KEY inside a JPEG image (for use with -k)"
+msgstr ""
+" bury         esconde uma CHAVE dentro de uma imagem JPEG (para uso com -k)"
+
+#: tomb:Commandline interaction:usage:796
+msgid " exhume       extract a KEY from a JPEG image (prints to stdout)"
+msgstr ""
+" exhume       extrai uma CHAVE de uma imagem JPEG (imprime para stdout)"
+
+#: tomb:Commandline interaction:usage:799
+msgid " cloak        transform a KEY into TEXT using CIPHER (for use with -k)"
+msgstr ""
+" cloak        transforma uma CHAVE em TEXTO usando a CIFRA (para uso com -k)"
+
+#: tomb:Commandline interaction:usage:802
+msgid " uncloak      extract a KEY from a TEXT using CIPHER (prints to stdout)"
+msgstr ""
+" uncloak      extrai uma CHAVE de um TEXTO usando a CIFRA (imprime para "
+"stdout)"
+
+#: tomb:Commandline interaction:usage:806
+msgid "Options:"
+msgstr "Opções:"
+
+#: tomb:Commandline interaction:usage:808
+msgid " -s           size of the tomb file when creating/resizing one (in MiB)"
+msgstr ""
+" -s           tamanho do arquivo de tumba a criar/redimensionar (em MiB)"
+
+#: tomb:Commandline interaction:usage:809
+msgid " -k           path to the key to be used ('-k -' to read from stdin)"
+msgstr ""
+" -k           caminho para a chave a ser usada ('-k -' para ler de stdin)"
+
+#: tomb:Commandline interaction:usage:810
+msgid " -n           don't launch the execution hooks found in tomb"
+msgstr " -n           não inicia os ganchos de execução encontrados na tumba"
+
+#: tomb:Commandline interaction:usage:811
+msgid " -p           preserve the ownership of all files in tomb"
+msgstr " -p           preserva a propriedade de todos os arquivos na tumba"
+
+#: tomb:Commandline interaction:usage:812
+msgid " -o           options passed to commands: open, lock, forge (see man)"
+msgstr ""
+" -o           opções passadas aos comandos: open, lock, forge (veja man)"
+
+#: tomb:Commandline interaction:usage:813
+msgid " -f           force operation (i.e. even if swap is active)"
+msgstr " -f           força a operação (mesmo que a swap esteja ativa)"
+
+#: tomb:Commandline interaction:usage:814
+msgid " -g           use a GnuPG key to encrypt a tomb key"
+msgstr " -g           usa a chave GnuPG para encriptar uma chave de tumba"
+
+#: tomb:Commandline interaction:usage:815
+msgid " -r           provide GnuPG recipients (separated by comma)"
+msgstr " -r           fornece destinatários GnuPG (separados por vírgula)"
+
+#: tomb:Commandline interaction:usage:816
+msgid " -R           provide GnuPG hidden recipients (separated by comma)"
+msgstr ""
+" -R           fornece destinatários GnuPG ocultos (separados por vírgula)"
+
+#: tomb:Commandline interaction:usage:817
+msgid " --sudo       super user exec alternative to sudo (doas or none)"
+msgstr ""
+" --sudo       executável de superusuário alternativo ao sudo (doas ou nenhum)"
+
+#: tomb:Commandline interaction:usage:820
+msgid ""
+" --sphx-user  user associated with the key (for use with pitchforkedsphinx)"
+msgstr ""
+" --sphx-user  usuário associado com a chave (para uso com pitchforkedsphinx)"
+
+#: tomb:Commandline interaction:usage:821
+msgid ""
+" --sphx-host  host associated with the key (for use with pitchforkedsphinx)"
+msgstr ""
+" --sphx-host  host associado com a chave (para uso com pitchforkedsphinx)"
+
+#: tomb:Commandline interaction:usage:825
+msgid " --kdf        forge keys armored against dictionary attacks"
+msgstr " --kdf        forja chaves protegidas contra ataques de dicionário"
+
+#: tomb:Commandline interaction:usage:829
+msgid " -h           print this help"
+msgstr " -h           imprime essa ajuda"
+
+#: tomb:Commandline interaction:usage:830
+msgid " -v           print version, license and list of available ciphers"
+msgstr " -v           imprime versão, licença e lista de cifras disponíveis"
+
+#: tomb:Commandline interaction:usage:831
+msgid " -q           run quietly without printing informations"
+msgstr " -q           executa em silêncio sem imprimir informações"
+
+#: tomb:Commandline interaction:usage:832
+msgid " -D           print debugging information at runtime"
+msgstr " -D           imprime informações de depuração em tempo de execução"
+
+#: tomb:Commandline interaction:usage:834
+msgid "For more information on Tomb read the manual: man tomb"
+msgstr "Para mais informações sobre Tomb, leia o manual: man tomb"
+
+#: tomb:Commandline interaction:usage:835
+msgid "Please report bugs on <http://github.com/dyne/tomb/issues>."
+msgstr "Reporte bugs em <http://github.com/dyne/tomb/issues>."
+
+#: tomb:Commandline interaction:_ensure_dependencies:992
+msgid "Missing required dependency ::1 command::.  Please install it."
+msgstr "Falta uma dependência necessária::1 comando::.  Por favor, instale-a."
+
+#: tomb:Commandline interaction:_ensure_dependencies:1004
+msgid "No privilege escalation tool found, not even sudo"
+msgstr ""
+"Nenhuma ferramenta de escalação de privilégios encontrada, nem mesmo sudo"
+
+#: tomb:Key operations:is_valid_recipients:1052
+msgid "Not a valid GPG key ID: ::1 gpgid:: "
+msgstr "Não é um ID de chave GPG válida: ::1 gpgid:: "
+
+#: tomb:Key operations:is_valid_recipients:1056
+msgid "The key ::1 gpgid:: is not trusted enough"
+msgstr "A chave ::1 gpgid:: não é confiável o suficiente"
+
+#: tomb:Key operations:is_valid_key:1107
+msgid "cleartext key from stdin selected: this is unsafe."
+msgstr ""
+"chave de texto não criptografado selecionada de stdin: isso não é seguro."
+
+#: tomb:Key operations:is_valid_key:1108
+msgid "please use --unsafe if you really want to do this."
+msgstr "por favor, use --unsafe se você realmente quiser fazer isso."
+
+#: tomb:Key operations:is_valid_key:1110
+msgid "received key in cleartext from stdin (unsafe mode)"
+msgstr "chave recebida em texto não criptografado de stdin (modo inseguro)"
+
+#: tomb:Key operations:is_valid_key:1114
+msgid "is_valid_key() called without an argument."
+msgstr "função is_valid_key() chamada sem um argumento."
+
+#: tomb:Key operations:is_valid_key:1122
+msgid "Key is an image, it might be valid."
+msgstr "A chave é uma imagem, pode ser válida."
+
+#: tomb:Key operations:is_valid_key:1128
+msgid "Key is missing KDF header."
+msgstr "Falta o cabeçalho KDF da chave."
+
+#: tomb:Key operations:is_valid_key:1134
+msgid "Key is valid."
+msgstr "A chave é valida."
+
+#: tomb:Key operations:recover_key:1144
+msgid "Attempting key recovery."
+msgstr "Tentativa de recuperação de chave."
+
+#: tomb:Key operations:_load_key:1168
+msgid "This operation requires a key file to be specified using the -k option."
+msgstr ""
+"Esta operação requer que um arquivo de chave seja especificado usando a "
+"opção -k."
+
+#: tomb:Key operations:_load_key:1172
+msgid "Waiting for the key to be piped from stdin... "
+msgstr "Aguardando a chave ser canalizada de stdin... "
+
+#: tomb:Key operations:_load_key:1183
+msgid "Key not found, specify one using -k."
+msgstr "Chave não encontrada, especifique uma usando -k."
+
+#: tomb:Key operations:_load_key:1198
+msgid ""
+"The key seems invalid or its format is not known by this version of Tomb."
+msgstr ""
+"A chave parece inválida ou seu formato não é conhecido por esta versão do "
+"Tomb."
+
+#: tomb:Key operations:gpg_decrypt:1229
+msgid "You set an invalid GPG ID."
+msgstr "Você definiu um ID GPG inválido."
+
+#: tomb:Key operations:get_lukskey:1281
+msgid "Unlocking KDF key protection (::1 kdf::)"
+msgstr "Desbloqueando a proteção de chave KDF (::1 kdf::)"
+
+#: tomb:Key operations:get_lukskey:1300
+msgid "No suitable program for KDF ::1 program::."
+msgstr "Nenhum programa adequado para KDF ::1 programa::."
+
+#: tomb:Key operations:get_lukskey:1316
+msgid "User aborted password dialog."
+msgstr "Diálogo de senha abortado pelo usuário."
+
+#: tomb:Key operations:ask_key_password:1340
+msgid "Internal error: ask_key_password() called before _load_key()."
+msgstr "Erro interno: função ask_key_password() chamada antes de _load_key()."
+
+#: tomb:Key operations:ask_key_password:1352
+msgid "A password is required to use key ::1 key::"
+msgstr "Uma senha é necessária para usar a chave ::1 chave::"
+
+#: tomb:Key operations:ask_key_password:1371
+msgid "Password OK."
+msgstr "Senha OK."
+
+#: tomb:Key operations:change_passwd:1419
+msgid "Commanded to change GnuPG key for tomb key ::1 key::"
+msgstr "Ordenado a alterar a chave GnuPG da chave da tumba ::1 chave::"
+
+#: tomb:Key operations:change_passwd:1421
+msgid "Commanded to change password for tomb key ::1 key::"
+msgstr "Ordenado a alterar a senha da chave da chave tumba ::1 chave::"
+
+#: tomb:Key operations:change_passwd:1434
+msgid "No valid password supplied."
+msgstr "Nenhuma senha válida fornecida."
+
+#: tomb:Key operations:change_passwd:1437
+msgid "Changing GnuPG key for ::1 key file::"
+msgstr "Alterando a chave GnuPG para ::1 arquivo de chave::"
+
+#: tomb:Key operations:change_passwd:1439
+msgid "Changing password for ::1 key file::"
+msgstr "Alterando a senha para ::1 arquivo de chave::"
+
+#: tomb:Key operations:change_passwd:1453
+msgid "Error: the newly generated keyfile does not seem valid."
+msgstr "Erro: o arquivo de chave recém-criado não parece válido."
+
+#: tomb:Key operations:change_passwd:1458
+msgid "Your GnuPG key was successfully changed"
+msgstr "Sua chave GnuPG foi alterada com sucesso"
+
+#: tomb:Key operations:change_passwd:1460
+msgid "Your passphrase was successfully updated."
+msgstr "Sua senha foi atualizada com sucesso."
+
+#: tomb:Key operations:gen_key:1511
+msgid ""
+"You are going to encrypt a tomb key with ::1 nrecipients:: recipient(s)."
+msgstr ""
+"Você vai criptografar uma chave de tumba com ::1 nrecipients:: "
+"destinatário(s)."
+
+#: tomb:Key operations:gen_key:1512
+msgid "It is your responsibility to check these fingerprints."
+msgstr "É sua responsabilidade verificar essas fingerprints."
+
+#: tomb:Key operations:gen_key:1513
+msgid "The fingerprints are:"
+msgstr "As fingerprints são:"
+
+#: tomb:Key operations:gen_key:1515
+msgid "\t  `_gpg_fingerprint "
+msgstr "\t  `_gpg_fingerprint "
+
+#: tomb:Key operations:gen_key:1520
+msgid "No recipient specified, using default GPG key."
+msgstr "Nenhum destinatário especificado, usando a chave GPG padrão."
+
+#: tomb:Key operations:gen_key:1533
+msgid "User aborted."
+msgstr "Usuário abortou."
+
+#: tomb:Key operations:gen_key:1536
+msgid "You set empty password, which is not possible."
+msgstr "Você definiu uma senha vazia, o que não é possível."
+
+#: tomb:Key operations:gen_key:1577
+msgid ""
+"Wrong argument for --kdf: must be an integer number (iteration seconds)."
+msgstr ""
+"Argumento incorreto para --kdf: deve ser um número inteiro (segundos de "
+"iteração)."
+
+#: tomb:Key operations:gen_key:1578
+msgid ""
+"Depending on the speed of machines using this tomb, use 1 to 10, or more"
+msgstr ""
+"Dependendo da velocidade das máquinas que usam tomb, use de 1 a 10, ou mais"
+
+#: tomb:Key operations:gen_key:1589
+msgid "Using KDF, iteration time: ::1 microseconds::"
+msgstr "Usando KDF, tempo de iteração: ::1 microssegundos::"
+
+#: tomb:Key operations:gen_key:1590
+msgid "generating salt"
+msgstr "gerando salt"
+
+#: tomb:Key operations:gen_key:1592
+msgid "calculating iterations"
+msgstr "calculando iterações"
+
+#: tomb:Key operations:gen_key:1594
+msgid "encoding the password"
+msgstr "codificando a senha"
+
+#: tomb:Key operations:gen_key:1601
+msgid "Using KDF Argon2"
+msgstr "Usando Argon2 como KDF"
+
+#: tomb:Key operations:gen_key:1604
+msgid "memory used: 2^::1 kdfmemory::"
+msgstr "memória usada: 2^::1 kdfmemory::"
+
+#: tomb:Key operations:gen_key:1606
+msgid "kdf salt: ::1 kdfsalt::"
+msgstr "kdf salt: ::1 kdfsalt::"
+
+#: tomb:Key operations:gen_key:1607
+msgid "kdf iterations: ::1 kdfiterations::"
+msgstr "iterações kdf: ::1 kdfiterations::"
+
+#: tomb:Key operations:bury_key:1667
+msgid "Encode failed: ::1 image file:: is not a jpeg image."
+msgstr "Falha na codificação: ::1 arquivo de imagem:: não é uma imagem jpeg."
+
+#: tomb:Key operations:bury_key:1671
+msgid "Encoding key ::1 tomb key:: inside image ::2 image file::"
+msgstr ""
+"Codificando chave ::1 chave da tumba:: dentro da imagem ::2 arquivo de "
+"imagem::"
+
+#: tomb:Key operations:bury_key:1673
+msgid "Using GnuPG Key ID"
+msgstr "Usando o ID da Chave GnuPG"
+
+#: tomb:Key operations:bury_key:1675
+msgid "Please confirm the key password for the encoding"
+msgstr "Por favor, confirme a senha da chave para a codificação"
+
+#: tomb:Key operations:bury_key:1696
+msgid "Wrong password/GnuPG ID supplied."
+msgstr "Foi fornecida uma senha/ID GnuPG incorreta."
+
+#: tomb:Key operations:bury_key:1697
+msgid "You shall not bury a key whose password is unknown to you."
+msgstr "Você não deve enterrar uma chave cuja senha você desconheça."
+
+#: tomb:Key operations:bury_key:1737
+msgid "Encoding error: steghide reports problems."
+msgstr "Erro de codificação: steghide relata problemas."
+
+#: tomb:Key operations:bury_key:1740
+msgid "Tomb key encoded succesfully into image ::1 image file::"
+msgstr ""
+"Chave de tumba codificada com sucesso na imagem ::1 arquivo de imagem::"
+
+#: tomb:Key operations:exhume_key:1752
+msgid "Exhume failed, no image specified"
+msgstr "Exumação falhou, nenhuma imagem especificada"
+
+#: tomb:Key operations:exhume_key:1765
+msgid "Exhume failed, image file not found: ::1 image file::"
+msgstr ""
+"Exumação falhou, arquivo de imagem não encontrado: ::1 arquivo de imagem::"
+
+#: tomb:Key operations:exhume_key:1767
+msgid "Exhume failed: ::1 image file:: is not a jpeg image."
+msgstr "Exumação falhou: ::1 arquivo de imagem:: não é uma imagem jpeg."
+
+#: tomb:Key operations:exhume_key:1774
+msgid "Wrong password or no steganographic key found"
+msgstr "Senha errada ou nenhuma chave esteganográfica encontrada"
+
+#: tomb:Key operations:exhume_key:1785
+msgid "printing exhumed key on stdout"
+msgstr "imprimindo chave exumada em stdout"
+
+#: tomb:Key operations:exhume_key:1789
+msgid "File exists: ::1 tomb key::"
+msgstr "O arquivo existe: ::1 chave da tumba::"
+
+#: tomb:Key operations:exhume_key:1791
+msgid "Use of --force selected: overwriting."
+msgstr "Uso de --force selecionado: sobrescrevendo."
+
+#: tomb:Key operations:exhume_key:1794
+msgid "Make explicit use of --force to overwrite."
+msgstr "Faça uso explícito de --force para sobrescrever."
+
+#: tomb:Key operations:exhume_key:1795
+msgid "Refusing to overwrite file. Operation aborted."
+msgstr "Recusando-se a sobrescrever o arquivo. Operação abortada."
+
+#: tomb:Key operations:exhume_key:1798
+msgid "Trying to exhume a key out of image ::1 image file::"
+msgstr "Tentando exumar uma chave da imagem ::1 arquivo de imagem::"
+
+#: tomb:Key operations:exhume_key:1819
+msgid "Key succesfully exhumed to ::1 key::."
+msgstr "Chave exumada com sucesso para ::1 chave::."
+
+#: tomb:Key operations:exhume_key:1821
+msgid "Nothing found in ::1 image file::"
+msgstr "Nada encontrado em ::1 arquivo de imagem::"
+
+#: tomb:Key operations:cloakify_key:1843
+msgid "Encoding key ::1 tomb key:: using cipher ::2 cipher file::"
+msgstr ""
+"Codificando chave ::1 chave de tumba:: usando cifra ::2 arquivo de cifra::"
+
+#: tomb:Key operations:cloakify_key:1848
+msgid "printing cloaked key on stdout"
+msgstr "imprimindo chave camuflada em stdout"
+
+#: tomb:Key operations:cloakify_key:1852
+msgid "File exists: ::1 output file::"
+msgstr "O arquivo existe: ::1 arquivo de saída::"
+
+#: tomb:Key operations:cloakify_key:1864
+msgid "Encoding error: cloakify reports problems."
+msgstr "Erro de codificação: ocultação relata problemas."
+
+#: tomb:Key operations:cloakify_key:1867
+msgid "Tomb key encoded succesfully"
+msgstr "Chave da tumba codificada com sucesso"
+
+#: tomb:Key operations:decloakify_key:1879
+msgid "Uncloak failed, no text file specified"
+msgstr "Desocultação falhou, nenhum arquivo de texto foi especificado"
+
+#: tomb:Key operations:decloakify_key:1881
+msgid "Uncloak failed, no cipher file specified"
+msgstr "Desocultação falhou, nenhum arquivo de cifra foi especificado"
+
+#: tomb:Key operations:decloakify_key:1894
+msgid "Uncloak failed, text file not found: ::1 text file::"
+msgstr ""
+"Desocultação falhou, arquivo de texto não encontrado: ::1 arquivo de texto::"
+
+#: tomb:Key operations:decloakify_key:1897
+msgid "Uncloak failed, cipher file not found: ::1 cipher file::"
+msgstr ""
+"Desocultação falhou, arquivo de cifra não encontrado: ::1 arquivo de cifra::"
+
+#: tomb:Key operations:decloakify_key:1903
+msgid "printing uncloaked key on stdout"
+msgstr "imprimindo chave descoberta em stdout"
+
+#: tomb:Key operations:decloakify_key:1923
+msgid "Key succesfully uncloaked to ::1 key::."
+msgstr "Chave revelada com sucesso para ::1 chave::."
+
+#: tomb:Key operations:decloakify_key:1925
+msgid "Nothing found in ::1 text file::"
+msgstr "Nada encontrado em ::1 arquivo de texto::"
+
+#: tomb:Key operations:engrave_key:1942
+msgid "Rendering a printable QRCode for key: ::1 tomb key file::"
+msgstr ""
+"Renderizando um QRCode imprimível para a chave: ::1 arquivo de chave da "
+"tumba::"
+
+#: tomb:Key operations:engrave_key:1947
+msgid "QREncode reported an error."
+msgstr "QREncode relatou um erro."
+
+#: tomb:Key operations:engrave_key:1949
+msgid "Operation successful:"
+msgstr "Operação bem sucedida:"
+
+#: tomb:Create:dig_tomb:1983
+msgid "Commanded to dig tomb ::1 tomb path::"
+msgstr "Ordenado a a cavar a tumba ::1 caminho da tumba::"
+
+#: tomb:Create:dig_tomb:1985
+msgid "Missing path to tomb"
+msgstr "Falta o caminho para a tumba"
+
+#: tomb:Create:dig_tomb:1986
+msgid "Size argument missing, use -s"
+msgstr "Argumento de tamanho ausente, use -s"
+
+#: tomb:Create:dig_tomb:1987
+msgid "Size must be an integer (mebibytes)"
+msgstr "O tamanho deve ser um número inteiro (mebibytes)"
+
+#: tomb:Create:dig_tomb:1988
+msgid "Tombs can't be smaller than 10 mebibytes"
+msgstr "Tumbas não podem ser menores que 10 mebibytes"
+
+#: tomb:Create:dig_tomb:1991
+msgid "A tomb exists already. I'm not digging here:"
+msgstr "Já existe uma tumba. Eu não vou cavar aqui:"
+
+#: tomb:Create:dig_tomb:1996
+msgid "Creating a new tomb in ::1 tomb path::"
+msgstr "Criando uma nova tumba em ::1 caminho da tumba::"
+
+#: tomb:Create:dig_tomb:1997
+msgid "Generating ::1 tomb file:: of ::2 size::MiB"
+msgstr "Gerando ::1 arquivo tumba:: de ::2 tamanho::MiB"
+
+#: tomb:Create:dig_tomb:2001
+msgid "Error creating the tomb ::1 tomb path::"
+msgstr "Erro ao criar a tumba ::1 caminho da tumba::"
+
+#: tomb:Create:dig_tomb:2011
+msgid "Done digging ::1 tomb name::"
+msgstr "Concluída a escavação de ::1 nome da tumba::"
+
+#: tomb:Create:dig_tomb:2012
+msgid "Your tomb is not yet ready, you need to forge a key and lock it:"
+msgstr ""
+"Sua tumba ainda não está pronta, você precisa forjar uma chave e trancá-la:"
+
+#: tomb:Create:dig_tomb:2013
+msgid "tomb forge ::1 tomb path::.key"
+msgstr "tomb forge ::1 caminho da tumba::.key"
+
+#: tomb:Create:dig_tomb:2014
+msgid "tomb lock ::1 tomb path:: -k ::1 tomb path::.key"
+msgstr "tomb lock ::1 caminho da tumba:: -k ::1 caminho da tumba::.key"
+
+#: tomb:Create:forge_key:2036
+msgid "A filename needs to be specified using -k to forge a new key."
+msgstr ""
+"Um nome de arquivo precisa ser especificado usando -k para forjar uma nova "
+"chave."
+
+#: tomb:Create:forge_key:2038
+msgid "Commanded to forge key ::1 key::"
+msgstr "Ordenado a forjar chave ::1 chave::"
+
+#: tomb:Create:forge_key:2051
+msgid "Forging this key would overwrite an existing file. Operation aborted."
+msgstr ""
+"Forjar essa chave substituiria um arquivo existente. Operação abortada."
+
+#: tomb:Create:forge_key:2055
+msgid "Cannot generate encryption key."
+msgstr "Não é possível gerar a chave de criptografia."
+
+#: tomb:Create:forge_key:2063
+msgid "Commanded to forge key ::1 key:: with cipher algorithm ::2 algorithm::"
+msgstr ""
+"Ordenado a forjar a chave ::1 chave:: com algoritmo de cifra ::2 algoritmo::"
+
+#: tomb:Create:forge_key:2072
+msgid "This operation takes time. Keep using this computer on other tasks."
+msgstr ""
+"Esta operação leva tempo. Continue usando este computador em outras tarefas."
+
+#: tomb:Create:forge_key:2073
+msgid "Once done you will be asked to choose a password for your tomb."
+msgstr ""
+"Uma vez feito isso, você será solicitado a escolher uma senha para a sua "
+"tumba."
+
+#: tomb:Create:forge_key:2074
+msgid "To make it faster you can move the mouse around."
+msgstr "Para tornar mais rápido, você pode mover o mouse."
+
+#: tomb:Create:forge_key:2075
+msgid "If you are on a server, you can use an Entropy Generation Daemon."
+msgstr ""
+"Se você estiver em um servidor, poderá usar um Entropy Generation Daemon."
+
+#: tomb:Create:forge_key:2090
+msgid "Using GnuPG key(s) to encrypt your key: ::1 tomb key::"
+msgstr ""
+"Usando a(s) chave(s) GnuPG para criptografar sua chave: ::1 chave da tumba::"
+
+#: tomb:Create:forge_key:2092
+msgid "Choose the password of your key: ::1 tomb key::"
+msgstr "Escolha a senha para a sua chave: ::1 chave da tumba::"
+
+#: tomb:Create:forge_key:2094
+msgid "(You can also change it later using 'tomb passwd'.)"
+msgstr "(Você também pode alterá-la mais tarde usando 'tomb passwd'.)"
+
+#: tomb:Create:forge_key:2112
+msgid "The key does not seem to be valid."
+msgstr "A chave não parece ser válida."
+
+#: tomb:Create:forge_key:2113
+msgid "Dumping contents to screen:"
+msgstr "Despejando conteúdo para a tela:"
+
+#: tomb:Create:forge_key:2121
+msgid "Done forging ::1 key file::"
+msgstr "Concluída a forja de ::1 arquivo de chave::"
+
+#: tomb:Create:forge_key:2122
+msgid "Your key is ready:"
+msgstr "Sua chave está pronta:"
+
+#: tomb:Create:lock_tomb_with_key:2142
+msgid "No tomb specified for locking."
+msgstr "Nenhuma tumba foi especificada para trancar."
+
+#: tomb:Create:lock_tomb_with_key:2143
+msgid "Usage: tomb lock file.tomb -k file.tomb.key"
+msgstr "Uso: tomb lock arquivo.tomb -k arquivo.tomb.key"
+
+#: tomb:Create:lock_tomb_with_key:2150
+msgid "Commanded to lock tomb ::1 tomb file::"
+msgstr "Ordenado a trancar tumba ::1 arquivo tumba::"
+
+#: tomb:Create:lock_tomb_with_key:2153
+msgid "There is no tomb here. You have to dig it first."
+msgstr "Não há nenhuma tumba aqui. Você tem que cavar primeiro."
+
+#: tomb:Create:lock_tomb_with_key:2166
+msgid "Filesystem ::1 filesystem:: not supported on tombs smaller than 47MB."
+msgstr ""
+"Sistema de arquivos ::1 sistema de arquivos:: não suportado em tumbas "
+"menores que 47MB."
+
+#: tomb:Create:lock_tomb_with_key:2172
+msgid "Filesystem ::1 filesystem:: not supported on tombs smaller than 18MB."
+msgstr ""
+"Sistema de arquivos ::1 sistema de arquivos:: não suportado em tumbas "
+"menores que 18MB."
+
+#: tomb:Create:lock_tomb_with_key:2177
+msgid "Filesystem not supported: ::1 filesystem::"
+msgstr "Sistema de arquivos não suportado: ::1 sistema de arquivos::"
+
+#: tomb:Create:lock_tomb_with_key:2181
+msgid "Selected filesystem type $filesystem."
+msgstr "Tipo de sistema de arquivos selecionado $filesystem."
+
+#: tomb:Create:lock_tomb_with_key:2188
+msgid "Checking if the tomb is empty (we never step on somebody else's bones)."
+msgstr ""
+"Verificar se a tumba está vazia (não se pisa nos ossos de outra pessoa)."
+
+#: tomb:Create:lock_tomb_with_key:2192
+msgid "The tomb was already locked with another key."
+msgstr "A tumba já estava trancada com outra chave."
+
+#: tomb:Create:lock_tomb_with_key:2193
+msgid ""
+"Operation aborted. I cannot lock an already locked tomb. Go dig a new one."
+msgstr ""
+"Operação abortada. Não posso trancar uma tumba já trancada. Vá cavar outra."
+
+#: tomb:Create:lock_tomb_with_key:2195
+msgid "Fine, this tomb seems empty."
+msgstr "Tudo bem, esta tumba parece vazia."
+
+#: tomb:Create:lock_tomb_with_key:2203
+msgid "Locking using cipher: ::1 cipher::"
+msgstr "Fechando usando a cifra: ::1 cifra::"
+
+#: tomb:Create:lock_tomb_with_key:2215
+msgid "Locking ::1 tomb file:: with ::2 tomb key file::"
+msgstr "Trancando ::1 arquivo de tumba:: com ::2 arquivo de chave de tumba::"
+
+#: tomb:Create:lock_tomb_with_key:2217
+msgid "Formatting Luks mapped device."
+msgstr "Formatando o dispositivo mapeado Luks."
+
+#: tomb:Create:lock_tomb_with_key:2222
+msgid "cryptsetup luksFormat returned an error."
+msgstr "cryptsetup luksFormat retornou um erro."
+
+#: tomb:Create:lock_tomb_with_key:2227
+msgid "cryptsetup luksOpen returned an error."
+msgstr "cryptsetup luksOpen retornou um erro."
+
+#: tomb:Create:lock_tomb_with_key:2230
+msgid "Formatting your Tomb with $filesystem filesystem."
+msgstr "Formatando sua tumba com o sistema de arquivos $filesystem."
+
+#: tomb:Create:lock_tomb_with_key:2249
+msgid "Tomb format returned an error."
+msgstr "A formatação da tumba retornou um erro."
+
+#: tomb:Create:lock_tomb_with_key:2251
+msgid "Your tomb ::1 tomb file:: may be corrupted."
+msgstr "Sua tumba ::1 arquivo de tumba:: pode estar corrompida."
+
+#: tomb:Create:lock_tomb_with_key:2256
+msgid "Done locking ::1 tomb name:: using Luks dm-crypt ::2 cipher::"
+msgstr ""
+"Trancamento concluído ::1 nome da tumba:: usando Luks dm-crypt ::2 cifra::"
+
+#: tomb:Create:lock_tomb_with_key:2257
+msgid ""
+"Your tomb is ready in ::1 tomb path:: and secured with key ::2 tomb key::"
+msgstr ""
+"Sua tumba está pronta em ::1 caminho da tumba:: e protegida com a chave ::2 "
+"chave da tumba::"
+
+#: tomb:Create:change_tomb_key:2267
+msgid "Commanded to reset key for tomb ::1 tomb path::"
+msgstr "Ordenado a redefinir a chave para a tumba ::1 caminho da tumba::"
+
+#: tomb:Create:change_tomb_key:2270
+msgid "Command 'setkey' needs two arguments: the old key file and the tomb."
+msgstr ""
+"O comando 'setkey' precisa de dois argumentos: o arquivo de chave antigo e a "
+"tumba."
+
+#: tomb:Create:change_tomb_key:2271
+msgid "I.e:\ttomb -k new.tomb.key old.tomb.key secret.tomb"
+msgstr "I.e:\ttomb -k nova.tomb.key velha.tomb.key secret.tomb"
+
+#: tomb:Create:change_tomb_key:2272
+msgid "Execution aborted."
+msgstr "Execução abortada."
+
+#: tomb:Create:change_tomb_key:2284
+msgid "Not a valid LUKS encrypted volume: ::1 volume::"
+msgstr "Não é um volume criptografado LUKS válido: ::1 volume::"
+
+#: tomb:Create:change_tomb_key:2294
+msgid "Changing lock on tomb ::1 tomb name::"
+msgstr "Mudando a fechadura da tumba ::1 nome da tumba::"
+
+#: tomb:Create:change_tomb_key:2295
+msgid "Old key: ::1 old key::"
+msgstr "Chave antiga: ::1 chave antiga::"
+
+#: tomb:Create:change_tomb_key:2306
+msgid "No valid password supplied for the old key."
+msgstr "Não foi fornecida uma senha válida para a chave antiga."
+
+#: tomb:Create:change_tomb_key:2312
+msgid "Unexpected error in luksOpen."
+msgstr "Erro inesperado no luksOpen."
+
+#: tomb:Create:change_tomb_key:2316
+msgid "New key: ::1 key file::"
+msgstr "Nova chave: ::1 arquivo de chave::"
+
+#: tomb:Create:change_tomb_key:2326
+msgid "No valid password supplied for the new key."
+msgstr "Não foi fornecida uma senha válida para a nova chave."
+
+#: tomb:Create:change_tomb_key:2335
+msgid "Unexpected error in luksChangeKey."
+msgstr "Erro inesperado em luksChangeKey."
+
+#: tomb:Create:change_tomb_key:2337
+msgid "Unexpected error in luksClose."
+msgstr "Erro inesperado em luksClose."
+
+#: tomb:Create:change_tomb_key:2339
+msgid "Successfully changed key for tomb: ::1 tomb file::"
+msgstr "Chave alterada com sucesso para a tumba: ::1 arquivo da tumba::"
+
+#: tomb:Create:change_tomb_key:2340
+msgid "The new key is: ::1 new key::"
+msgstr "A nova chave é: ::1 nova chave::"
+
+#: tomb:Open:mount_tomb:2370
+msgid "No tomb name specified for opening."
+msgstr "Não foi especificada uma tumba para abrir."
+
+#: tomb:Open:mount_tomb:2372
+msgid "Commanded to open tomb ::1 tomb name::"
+msgstr "Ordenado a abrir a tumba ::1 nome da tumba::"
+
+#: tomb:Open:mount_tomb:2388
+msgid "Mountpoint not specified, using default: ::1 mount point::"
+msgstr ""
+"O ponto de montagem não foi especificado, usando o padrão: ::1 ponto de "
+"montagem::"
+
+#: tomb:Open:mount_tomb:2391
+msgid "Opening ::1 tomb file:: on ::2 mount point::"
+msgstr "Abrindo ::1 arquivo tumba:: em ::2 ponto de montagem::"
+
+#: tomb:Open:mount_tomb:2398
+msgid "Mountpoint already in use: ::1 mount point::"
+msgstr "O ponto de montagem já está em uso: ::1 ponto de montagem::"
+
+#: tomb:Open:mount_tomb:2405
+msgid "::1 tomb file:: is not a valid Luks encrypted storage file."
+msgstr ""
+"::1 arquivo tumba:: não é um arquivo de armazenamento criptografado Luks "
+"válido."
+
+#: tomb:Open:mount_tomb:2407
+msgid "This tomb is a valid LUKS encrypted device."
+msgstr "Esta tumba é um dispositivo criptografado LUKS válido."
+
+#: tomb:Open:mount_tomb:2414
+msgid "Cipher is \"::1 cipher::\" mode \"::2 mode::\" hash \"::3 hash::\""
+msgstr "A cifra é \"::1 cifra::\" modo \"::2 modo::\" hash \"::3 hash::\""
+
+#: tomb:Open:mount_tomb:2421
+msgid ""
+"Multiple key slots are enabled on this tomb. Beware: there can be a backdoor."
+msgstr ""
+"Múltiplos slots de chave estão habilitados nesta tumba. Cuidado: pode haver "
+"um backdoor."
+
+#: tomb:Open:mount_tomb:2439
+msgid "Failure mounting the encrypted file."
+msgstr "Falha ao montar o arquivo criptografado."
+
+#: tomb:Open:mount_tomb:2449
+msgid "Success unlocking tomb ::1 tomb name::"
+msgstr "Tumba desbloqueada com sucesso: ::1 nome da tumba::"
+
+#: tomb:Open:mount_tomb:2453
+msgid "Filesystem detected: ::1 filesystem::"
+msgstr "Sistema de arquivos detectado: ::1 sistema de arquivos::"
+
+#: tomb:Open:mount_tomb:2459
+msgid "Skipping filesystem checks in read-only"
+msgstr "Ignorando verificações do sistema de arquivos em somente leitura"
+
+#: tomb:Open:mount_tomb:2461
+msgid "Checking filesystem via ::1::"
+msgstr "Verificando o sistema de arquivos via ::1::"
+
+#: tomb:Open:mount_tomb:2491
+msgid "Error mounting ::1 mapper:: on ::2 tombmount::"
+msgstr "Erro ao montar ::1 mapper:: em ::2 tombmount::"
+
+#: tomb:Open:mount_tomb:2493
+msgid "Are mount options '::1 mount options::' valid?"
+msgstr "As opções de montagem '::1 opções de montagem::' são válidas?"
+
+#: tomb:Open:mount_tomb:2498
+msgid "Cannot mount ::1 tomb name::"
+msgstr "Não é possível montar ::1 nome da tumba::"
+
+#: tomb:Open:mount_tomb:2501
+msgid "Success opening ::1 tomb file:: on ::2 mount point::"
+msgstr "Sucesso ao abrir ::1 arquivo tumba:: em ::2 ponto de montagem::"
+
+#: tomb:Open:mount_tomb:2515
+msgid "Last visit by ::1 user::(::2 tomb build::) from ::3 tty:: on ::4 host::"
+msgstr ""
+"Última visita de ::1 usuário::(::2 tomb build::) de ::3 tty:: em ::4 host::"
+
+#: tomb:Open:mount_tomb:2516
+msgid "on date ::1 date::"
+msgstr "na data ::1 data::"
+
+#: tomb:Open:mount_tomb:2517
+msgid "the door was slammed or shutdown called before umount."
+msgstr "a porta foi batida ou um desligamento ocorreu antes de desmontar."
+
+#: tomb:Open:exec_safe_bind_hooks:2579
+msgid "How pitiful!\tA tomb, and no HOME."
+msgstr "Que pena!\tUma tumba e nenhuma HOME."
+
+#: tomb:Open:exec_safe_bind_hooks:2583
+msgid "Cannot exec bind hooks without a mounted tomb."
+msgstr "Não é possível executar bind-hooks sem uma tumba montada."
+
+#: tomb:Open:exec_safe_bind_hooks:2599
+msgid "bind-hooks file is broken"
+msgstr "arquivo bind-hooks está quebrado"
+
+#: tomb:Open:exec_safe_bind_hooks:2608
+msgid "bind-hooks map format: local/to/tomb local/to/$HOME"
+msgstr "formato de mapa de bind-hooks: local/para/tumba local/para/$HOME"
+
+#: tomb:Open:exec_safe_bind_hooks:2612
+msgid "bind-hooks map format: local/to/tomb local/to/$HOME.\t Rolling back"
+msgstr ""
+"formato de mapa de bind-hooks: local/para/tumba local/para/$HOME.\t "
+"Revertendo"
+
+#: tomb:Open:exec_safe_bind_hooks:2617
+msgid "bind-hook target not existent, skipping ::1 home::/::2 subdir::"
+msgstr "alvo de bind-hook não existe, ignorando ::1 home::/::2 subdir::"
+
+#: tomb:Open:exec_safe_bind_hooks:2619
+msgid ""
+"bind-hook source not found in tomb, skipping ::1 mount point::/::2 subdir::"
+msgstr ""
+"origem do bind-hook não encontrada na tumba, ignorando ::1 ponto de "
+"montagem::/::2 subdiretório::"
+
+#: tomb:Open:exec_safe_func_hooks:2642
+msgid "Exec hook: ::1 exec hook:: ::2 action::"
+msgstr "Gancho de execução: ::1 exec hook:: ::2 ação::"
+
+#: tomb:List:list_tombs:2668
+msgid "I can't see any ::1 status:: tomb, may they all rest in peace."
+msgstr ""
+"Não consigo ver nenhuma tumba ::1 status::, que todos descansem em paz."
+
+#: tomb:List:list_tombs:2704
+msgid "::1 tombname:: open on ::2 tombmount:: using ::3 tombfsopts::"
+msgstr "::1 nome da tumba:: aberta em ::2 tombmount:: usando ::3 tombfsopts::"
+
+#: tomb:List:list_tombs:2709
+msgid "::1 tombname:: open since ::2 tombsince::"
+msgstr "::1 nome da tumba:: aberta desde ::2 tombsince::"
+
+#: tomb:List:list_tombs:2712
+msgid ""
+"::1 tombname:: open by ::2 tombuser:: from ::3 tombtty:: on ::4 tombhost::"
+msgstr ""
+"::1 nome da tumba:: aberta por ::2 tombuser:: de ::3 tombtty:: em ::4 "
+"tombhost::"
+
+#: tomb:List:list_tombs:2716
+msgid ""
+"::1 tombname:: size ::2 tombtot:: of which ::3 tombused:: (::5 tombpercent::"
+"%) is used: ::4 tombavail:: free "
+msgstr ""
+"::1 nome da tumba:: tamanho ::2 tombtot:: dos quais ::3 tombused:: (::5 "
+"tombpercent::%) em uso: ::4 tombavail:: livres "
+
+#: tomb:List:list_tombs:2720
+msgid "::1 tombname:: warning: your tomb is almost full!"
+msgstr "::1 nome da tumba:: aviso: sua tumba está quase cheia!"
+
+#: tomb:List:list_tombs:2726
+msgid "::1 tombname:: hooks ::2 hookdest::"
+msgstr "::1 nome da tumba:: hooks ::2 hookdest::"
+
+#: tomb:List:list_tomb_binds:2787
+msgid "Internal error: list_tomb_binds called without argument."
+msgstr "Erro interno: list_tomb_binds invocado sem argumento."
+
+#: tomb:Index and search:index_tombs:2816
+msgid "Cannot index tombs on this system: updatedb (mlocate) not installed."
+msgstr ""
+"Não é possível indexar tumbas neste sistema: updatedb (mlocate) não "
+"instalado."
+
+#: tomb:Index and search:index_tombs:2820
+msgid "Cannot use GNU findutils for index/search commands."
+msgstr "Não é possível usar GNU findutils para os comandos index/search."
+
+#: tomb:Index and search:index_tombs:2822
+msgid "Index command needs 'mlocate' to be installed."
+msgstr "O comando index precisa que 'mlocate' seja instalado."
+
+#: tomb:Index and search:index_tombs:2830
+msgid "There seems to be no open tomb engraved as [::1::]"
+msgstr "Parece não haver tumba aberta cinzelada como [::1::]"
+
+#: tomb:Index and search:index_tombs:2832
+msgid "I can't see any open tomb, may they all rest in peace."
+msgstr "Não vejo nenhuma tumba aberta, que todos descansem em paz."
+
+#: tomb:Index and search:index_tombs:2834
+msgid "Creating and updating search indexes."
+msgstr "Criando e atualização de índices de pesquisa."
+
+#: tomb:Index and search:index_tombs:2847
+msgid "Skipping ::1 tomb name:: (.noindex found)."
+msgstr "Ignorando ::1 nome da tumba:: (.noindex encontrado)."
+
+#: tomb:Index and search:index_tombs:2849
+msgid "Indexing ::1 tomb name:: filenames..."
+msgstr "Indexando ::1 nome da tumba:: nomes de arquivos..."
+
+#: tomb:Index and search:index_tombs:2854
+msgid "Indexing ::1 tomb name:: contents..."
+msgstr "Indexando ::1 nome da tumba:: conteúdo..."
+
+#: tomb:Index and search:index_tombs:2856
+msgid "Generating a new swish-e configuration file: ::1 swish conf::"
+msgstr "Gerando um novo arquivo de configuração swish-e: ::1 swish conf::"
+
+#: tomb:Index and search:index_tombs:2926
+msgid "Search index updated."
+msgstr "Índice de pesquisa atualizado."
+
+#: tomb:Index and search:search_tombs:2948
+msgid "Searching for: ::1::"
+msgstr "Procurando por: ::1::"
+
+#: tomb:Index and search:search_tombs:2956
+msgid "Searching filenames in tomb ::1 tomb name::"
+msgstr "Pesquisando arquivos na tumba ::1 nome da tumba::"
+
+#: tomb:Index and search:search_tombs:2958
+msgid "Matches found: ::1 matches::"
+msgstr "Correspondências encontradas: ::1 matches::"
+
+#: tomb:Index and search:search_tombs:2963
+msgid "Searching contents in tomb ::1 tomb name::"
+msgstr "Pesquisando conteúdo na tumba ::1 nome da tumba::"
+
+#: tomb:Index and search:search_tombs:2966
+msgid "Skipping tomb ::1 tomb name::: not indexed."
+msgstr "Ignorando tumba ::1 nome da tumba::: não indexada."
+
+#: tomb:Index and search:search_tombs:2967
+msgid "Run 'tomb index' to create indexes."
+msgstr "Execute 'tomb index' para criar índices."
+
+#: tomb:Index and search:search_tombs:2969
+msgid "Search completed."
+msgstr "Busca completada."
+
+#: tomb:Resize:resize_tomb:2981
+msgid "Commanded to resize tomb ::1 tomb name:: to ::2 size:: mebibytes."
+msgstr ""
+"Ordenado a redimensionar tumba ::1 nome da tumba:: para ::2 tamanho:: "
+"mebibytes."
+
+#: tomb:Resize:resize_tomb:2983
+msgid "No tomb name specified for resizing."
+msgstr "Nenhum nome de tumba especificado para redimensionamento."
+
+#: tomb:Resize:resize_tomb:2984
+msgid "Cannot find ::1::"
+msgstr "Não foi possível encontrar ::1::"
+
+#: tomb:Resize:resize_tomb:2988
+msgid "Aborting operations: new size was not specified, use -s"
+msgstr "Abortando operações: o novo tamanho não foi especificado, use -s"
+
+#: tomb:Resize:resize_tomb:3007
+msgid "You must specify the new size of ::1 tomb name::"
+msgstr "Você deve especificar o novo tamanho de ::1 nome da tumba::"
+
+#: tomb:Resize:resize_tomb:3009
+msgid "Size is not an integer."
+msgstr "O tamanho não é um número inteiro."
+
+#: tomb:Resize:resize_tomb:3021
+msgid "Error creating the extra resize ::1 size::, operation aborted."
+msgstr ""
+"Erro ao criar o redimensionamento extra ::1 tamanho::, operação abortada."
+
+#: tomb:Resize:resize_tomb:3028
+msgid "Tomb seems resized already, operating filesystem stretch"
+msgstr "A tumba já parece redimensionada, estendendo o sistema de arquivos"
+
+#: tomb:Resize:resize_tomb:3030
+msgid "The new size must be greater then old tomb size."
+msgstr "O novo tamanho deve ser maior que o antigo tamanho da tumba."
+
+#: tomb:Resize:resize_tomb:3035
+msgid "opening tomb"
+msgstr "abrindo tumba"
+
+#: tomb:Resize:resize_tomb:3040
+msgid "cryptsetup failed to resize ::1 mapper::"
+msgstr "cryptsetup falhou em redimensionar ::1 mapper::"
+
+#: tomb:Resize:resize_tomb:3049
+msgid "e2fsck failed to check ::1 mapper::"
+msgstr "e2fsck falhou em verificar ::1 mapper::"
+
+#: tomb:Resize:resize_tomb:3052
+msgid "resize2fs failed to resize ::1 mapper::"
+msgstr "resize2fs falhou em redimensionar ::1 mapper::"
+
+#: tomb:Resize:resize_tomb:3057
+msgid "filesystem check failed on ::1 mapper::"
+msgstr "verificação do sistema de arquivos falhou em ::1 mapper::"
+
+#: tomb:Resize:resize_tomb:3066
+msgid "filesystem resize failed on ::1 mapper::"
+msgstr "redimensionamento do sistema de arquivous falhou em ::1 mapper::"
+
+#: tomb:Close:umount_tomb:3095
+msgid "There is no open tomb to be closed."
+msgstr "Não há tumbas abertas para serem fechadas."
+
+#: tomb:Close:umount_tomb:3098
+msgid "Too many tombs mounted, please specify one (see tomb list)"
+msgstr ""
+"Muitas tumbas montadas, por favor, especifique uma (veja a lista de tumbas)"
+
+#: tomb:Close:umount_tomb:3099
+msgid "or issue the command 'tomb close all' to close them all."
+msgstr "ou execute o comando 'tomb close all' para fechar todas."
+
+#: tomb:Close:umount_tomb:3118
+msgid "Tomb not found: ::1 tomb file::"
+msgstr "Tumba não encontrada: ::1 arquivo de tumba::"
+
+#: tomb:Close:umount_tomb:3119
+msgid "Please specify an existing tomb."
+msgstr "Especifique uma tumba existente."
+
+#: tomb:Close:umount_tomb:3127
+msgid "close exec-hook returns a non-zero error code: ::1 error::"
+msgstr ""
+"fechar exec-hook retorna um código de erro diferente de zero: ::1 erro::"
+
+#: tomb:Close:umount_tomb:3128
+msgid "Operation aborted"
+msgstr "Operação abortada"
+
+#: tomb:Close:umount_tomb:3132
+msgid "Closing tomb ::1 tomb name:: mounted on ::2 mount point::"
+msgstr "Fechando tumba ::1 nome da tumba:: montada em ::2 ponto de montagem::"
+
+#: tomb:Close:umount_tomb:3140
+msgid "Closing tomb bind hook: ::1 hook::"
+msgstr "Fechando bind-hook da tumba: ::1 hook::"
+
+#: tomb:Close:umount_tomb:3142
+msgid "Tomb bind hook ::1 hook:: is busy, cannot close tomb."
+msgstr ""
+"Bind-hook da tumba ::1 hook:: está ocupado, não é possível fechar a tumba."
+
+#: tomb:Close:umount_tomb:3162
+msgid "Tomb is busy, cannot umount!"
+msgstr "A tumba está ocupada, não é possível desmontar!"
+
+#: tomb:Close:umount_tomb:3175
+msgid "Error occurred in cryptsetup luksClose ::1 mapper::"
+msgstr "Ocorreu um erro no cryptsetup luksClose ::1 mapper::"
+
+#: tomb:Close:umount_tomb:3183
+msgid "Tomb ::1 tomb name:: closed: your bones will rest in peace."
+msgstr "Tumba ::1 nome da tumba:: fechada: seus ossos descansarão em paz."
+
+#: tomb:Close:list_processes:3199
+msgid "Listing processes running inside all open tombs..."
+msgstr "Listando processos em execução dentro de todas as tumbas abertas..."
+
+#: tomb:Close:list_processes:3201
+msgid "Listing processes running inside tomb '::1 tombname::'..."
+msgstr ""
+"Listando processos em execução dentro da tumba '::1 nome da tumba::'..."
+
+#: tomb:Close:list_processes:3215
+msgid "::1 tombname:: ::2 cmd:: (::3 owner::)"
+msgstr "::1 nome da tumba:: ::2 cmd:: (::3 proprietário::)"
+
+#: tomb:Close:list_processes:3220
+msgid ""
+"::1 foundproc:: running processes found inside ::2 numtombs:: open tombs"
+msgstr ""
+"::1 foundproc:: processos em execução encontrados dentro de ::2 numtombs:: "
+"tumba(s) aberta(s)"
+
+#: tomb:Close:slam_tomb:3249
+msgid "Slamming tomb ::1 tombname:: mounted on ::2 tombmount::"
+msgstr "Fechando tumba ::1 tombname:: montada em ::2 tombmount::"
+
+#: tomb:Close:slam_tomb:3259
+msgid "::1 tombname:: sending ::2 sig:: to ::3 cmd:: (::4 uid::)"
+msgstr "::1 nome da tumba:: enviando ::2 sig:: para ::3 cmd:: (::4 uid::)"
+
+#: tomb:Close:slam_tomb:3269
+msgid "Can't kill ::1 process:: ::2 pcmd:: (::3 powner::)"
+msgstr "Não é possível matar ::1 processo:: ::2 pcmd:: (::3 powner::)"
+
+#: tomb:Main routine:main:3369
+msgid "Error parsing."
+msgstr "Erro ao analisar."
+
+#: tomb:Main routine:main:3379
+msgid "There's no such command \"::1 subcommand::\"."
+msgstr "O comando \"::1 subcomando::\" não existe."
+
+#: tomb:Main routine:main:3380
+msgid "Please try -h for help."
+msgstr "Por favor, tente -h para ajuda."
+
+#: tomb:Main routine:main:3392
+msgid "Some error occurred during option processing."
+msgstr "Ocorreu algum erro durante o processamento da opção."
+
+#: tomb:Main routine:main:3393
+msgid "See \"tomb help\" for more info."
+msgstr "Consulte \"tomb help\" para obter mais informações."
+
+#: tomb:Main routine:main:3405
+msgid "Unrecognized option ::1 arg:: for subcommand ::2 subcommand::"
+msgstr "Opção não reconhecida ::1 arg:: para subcomando ::2 subcomando::"
+
+#: tomb:Main routine:main:3421
+msgid ""
+"You specified option ::1 option::, which is DANGEROUS and should only be "
+"used for testing\n"
+"If you really want so, add --unsafe"
+msgstr ""
+"Você especificou a opção ::1 opção::, que é PERIGOSA e só deve ser usada "
+"para teste\n"
+"Se você realmente quiser, adicione --unsafe"
+
+#: tomb:Main routine:main:3429
+msgid "Privilege escalation tool configured: ::1 exec::"
+msgstr "Ferramenta de escalação de privilégios configurada: ::1 exec::"
+
+#: tomb:Main routine:main:3459
+msgid ""
+"The create command is deprecated, please use dig, forge and lock instead."
+msgstr ""
+"O comando create está obsoleto, por favor, use dig, forge e lock em seu "
+"lugar."
+
+#: tomb:Main routine:main:3460
+msgid "For more informations see Tomb's manual page (man tomb)."
+msgstr "Para mais informações veja a página de manual do Tomb (man tomb)."
+
+#: tomb:Main routine:main:3501
+msgid "lsof not installed: cannot slam tombs."
+msgstr "lsof não instalado: não pode fechar tumbas com \"slam\"."
+
+#: tomb:Main routine:main:3502
+msgid "Trying a regular close."
+msgstr "Tentando um fechamento regular."
+
+#: tomb:Main routine:main:3509
+msgid "Resize2fs not installed: cannot resize tombs."
+msgstr "Resize2fs não instalado: não é possível redimensionar tumbas."
+
+#: tomb:Main routine:main:3535
+msgid "QREncode not installed: cannot engrave keys on paper."
+msgstr "QREncode não instalado: não é possível gravar chaves no papel."
+
+#: tomb:Main routine:main:3552
+msgid "Steghide not installed: cannot bury keys into images."
+msgstr "Steghide não instalado: não é possível enterrar chaves em imagens."
+
+#: tomb:Main routine:main:3559
+msgid "Steghide not installed: cannot exhume keys from images."
+msgstr "Steghide não instalado: não é possível exumar chaves de imagens."
+
+#: tomb:Main routine:main:3566
+msgid "Cloakify not installed: cannot cipher keys into texts"
+msgstr "Cloakify não instalado: não é possível cifrar chaves em textos"
+
+#: tomb:Main routine:main:3573
+msgid "Decloakify not installed: cannot decipher keys from texts"
+msgstr "Decloakify não instalado: não é possível decifrar chaves de textos"
+
+#: tomb:Main routine:main:3588
+msgid "Tomb ::1 version:: - a strong and gentle undertaker for your secrets"
+msgstr ""
+"Tomb ::1 versão:: - um agente funerário forte e gentil para os seus segredos"
+
+#: tomb:Main routine:main:3590
+msgid " Copyright (C) 2007-2021 Dyne.org Foundation, License GNU GPL v3+"
+msgstr " Copyright (C) 2007-2021 Dyne.org Foundation, Licença GNU GPL v3+"
+
+#: tomb:Main routine:main:3591
+msgid " This is free software: you are free to change and redistribute it"
+msgstr ""
+" Este é um software livre: você é livre para alterá-lo e redistribuí-lo"
+
+#: tomb:Main routine:main:3592
+msgid " For the latest sourcecode go to <http://dyne.org/software/tomb>"
+msgstr ""
+" Para obter o código-fonte mais atual, acesse <http://dyne.org/software/tomb>"
+
+#: tomb:Main routine:main:3597
+msgid " This source code is distributed in the hope that it will be useful,"
+msgstr " Este código-fonte é distribuído na esperança de que seja útil,"
+
+#: tomb:Main routine:main:3598
+msgid " but WITHOUT ANY WARRANTY; without even the implied warranty of"
+msgstr " mas SEM QUALQUER GARANTIA; nem mesmo a garantia implícita de"
+
+#: tomb:Main routine:main:3599
+msgid " MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+msgstr " COMERCIABILIDADE ou ADEQUAÇÃO A UM DETERMINADO FIM."
+
+#: tomb:Main routine:main:3601
+msgid " When in need please refer to <http://dyne.org/support>."
+msgstr " Quando necessário, por favor consulte <http://dyne.org/support>."
+
+#: tomb:Main routine:main:3603
+msgid "System utils:"
+msgstr "Utilitários de sistema:"
+
+#: tomb:Main routine:main:3615
+msgid "Optional utils:"
+msgstr "Utilitários opcionais:"
+
+#: tomb:Main routine:main:3625
+msgid "Command \"::1 subcommand::\" not recognized."
+msgstr "Comando \"::1 subcomando::\" não reconhecido."
+
+#: tomb:Main routine:main:3626
+msgid "Try -h for help."
+msgstr "Tente -h para ajuda."

--- a/extras/translations/pt_BR.po
+++ b/extras/translations/pt_BR.po
@@ -4,1162 +4,1254 @@
 #
 msgid ""
 msgstr ""
-"PO-Revision-Date: Mon Jan  2 22:40:32 2017\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2023-06-27 13:46-0300\n"
+"Last-Translator: Daniel Dias Rodrigues <danieldiasr@gmail.com>\n"
+"Language-Team: Tomb developers <crypto@lists.dyne.org>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #: tomb:Safety functions:_sudo:124
 msgid "[sudo] Enter password for user ::1 user:: to gain superuser privileges"
 msgstr ""
+"[sudo] Digite a senha do usuário ::1 usuário:: para obter privilégios de "
+"superusuário"
 
 #: tomb:Safety functions:_whoami:200
 msgid "Failing to identify the user who is calling us"
-msgstr ""
+msgstr "Falha ao identificar o usuário que está nos chamando"
 
 #: tomb:Safety functions:_plot:249
 msgid "Tomb won't work without a TOMBNAME."
-msgstr ""
+msgstr "Tomb não funcionará sem uma TOMBNAME."
 
 #: tomb:Safety functions:_tmp_create:258
 msgid "Fatal error creating the temporary directory: ::1 temp dir::"
-msgstr ""
+msgstr "Erro fatal ao criar o diretório temporário: ::1 diretório temporário::"
 
 #: tomb:Safety functions:_tmp_create:266
 msgid "Fatal error setting the permission umask for temporary files"
-msgstr ""
+msgstr "Erro fatal ao definir a permissão umask para arquivos temporários"
 
 #: tomb:Safety functions:_tmp_create:269
 msgid "Someone is messing up with us trying to hijack temporary files."
 msgstr ""
+"Alguém está nos atrapalhando tentando sequestrar arquivos temporários "
+"(\"hijack\")."
 
 #: tomb:Safety functions:_tmp_create:273
 msgid "Fatal error creating a temporary file: ::1 temp file::"
-msgstr ""
+msgstr "Erro fatal ao criar um arquivo temporário: ::1 arquivo temporário::"
 
 #: tomb:Safety functions:_ensure_safe_swap:316
 msgid "An active swap partition is detected..."
-msgstr ""
+msgstr "Foi detectada uma partição swap ativa..."
 
 #: tomb:Safety functions:_ensure_safe_swap:330
 msgid "The undertaker found that all swap partitions are encrypted. Good."
 msgstr ""
+"O agente funerário descobriu que todas as partições swap são criptografadas. "
+"Bom."
 
 #: tomb:Safety functions:_ensure_safe_swap:332
 msgid "This poses a security risk."
-msgstr ""
+msgstr "Isso representa um risco de segurança."
 
 #: tomb:Safety functions:_ensure_safe_swap:333
 msgid "You can deactivate all swap partitions using the command:"
-msgstr ""
+msgstr "Você pode desativar todas as partições swap usando o comando:"
 
 #: tomb:Safety functions:_ensure_safe_swap:334
 msgid " swapoff -a"
-msgstr ""
+msgstr " swapoff -a"
 
 #: tomb:Safety functions:_ensure_safe_swap:335
 msgid "[#163] I may not detect plain swaps on an encrypted volume."
-msgstr ""
+msgstr "[#163] Posso não detectar swaps simples em um volume criptografado."
 
 #: tomb:Safety functions:_ensure_safe_swap:336
 msgid "But if you want to proceed like this, use the -f (force) flag."
-msgstr ""
+msgstr "Mas se quiser prosseguir desse modo, use o sinalizador -f (forçar)."
 
 #: tomb:Safety functions:_check_swap:355
 msgid "Operation aborted."
-msgstr ""
+msgstr "Operação abortada."
 
 #: tomb:Safety functions:ask_password:397
 msgid "Cannot find pinentry-curses and no DISPLAY detected."
 msgstr ""
+"Não foi possível encontrar o pinentry-curses e nenhum DISPLAY foi detectado."
 
 #: tomb:Safety functions:ask_password:459
 msgid "Detected DISPLAY, but only pinentry-curses is found."
-msgstr ""
+msgstr "Um DISPLAY foi detectado, mas apenas o pinentry-curses foi encontrado."
 
 #: tomb:Safety functions:ask_password:469
 msgid "Cannot find any pinentry: impossible to ask for password."
-msgstr ""
+msgstr "Não foi possível encontrar nenhum pinentry: impossível pedir a senha."
 
 #: tomb:Safety functions:ask_password:479
 msgid "Pinentry error: ::1 error::"
-msgstr ""
+msgstr "Erro pinentry: ::1 erro::"
 
 #: tomb:Safety functions:ask_password:489
 msgid "Empty password"
-msgstr ""
+msgstr "Senha vazia"
 
 #: tomb:Safety functions:is_valid_tomb:506
 msgid "Tomb file is missing from arguments."
-msgstr ""
+msgstr "Está faltando nos argumentos o arquivo de tumba."
 
 #: tomb:Safety functions:is_valid_tomb:511
 msgid "Tomb file is not writable: ::1 tomb file::"
-msgstr ""
+msgstr "O arquivo de tumba não é gravável: ::1 arquivo tumba::"
 
 #: tomb:Safety functions:is_valid_tomb:517
 msgid "Tomb file is not a regular file: ::1 tomb file::"
-msgstr ""
+msgstr "O arquivo de tumba não é um arquivo regular: ::1 arquivo tumba::"
 
 #: tomb:Safety functions:is_valid_tomb:523
 msgid "Tomb file is empty (zero length): ::1 tomb file::"
-msgstr ""
+msgstr "O arquivo de tumba está vazio (comprimento zero): ::1 arquivo tumba::"
 
 #: tomb:Safety functions:is_valid_tomb:532
 msgid "Tomb file is owned by another user: ::1 tomb owner::"
 msgstr ""
+"O arquivo de tumba pertence a outro usuário: ::1 proprietário da tumba::"
 
 #: tomb:Safety functions:is_valid_tomb:537
 msgid "Tomb command failed: ::1 command name::"
-msgstr ""
+msgstr "Comando Tomb falhou: ::1 nome do comando::"
 
 #: tomb:Safety functions:is_valid_tomb:546
 msgid "File is not yet a tomb: ::1 tomb file::"
-msgstr ""
+msgstr "O arquivo ainda não é uma tumba: ::1 arquivo tumba::"
 
 #: tomb:Safety functions:is_valid_tomb:554
 msgid "Tomb is currently in use: ::1 tomb name::"
-msgstr ""
+msgstr "A tumba está atualmente em uso: ::1 nome da tumba::"
 
 #: tomb:Safety functions:is_valid_tomb:558
 msgid "Valid tomb file found: ::1 tomb path::"
-msgstr ""
+msgstr "Encontrado arquivo de tumba válido: ::1 caminho da tumba::"
 
 #: tomb:Safety functions:lo_mount:570
 msgid "Loop mount of volumes is not possible on this machine, this error"
-msgstr ""
+msgstr "A montagem em loop de volumes não é possível nesta máquina, este erro"
 
 #: tomb:Safety functions:lo_mount:571
 msgid "often occurs on VPS and kernels that don't provide the loop module."
-msgstr ""
+msgstr "geralmente ocorre em VPS e kernels que não fornecem o módulo de loop."
 
 #: tomb:Safety functions:lo_mount:572
 msgid "It is impossible to use Tomb on this machine at this conditions."
-msgstr ""
+msgstr "É impossível usar Tomb nesta máquina nestas condições."
 
 #: tomb:Commandline interaction:usage:612
 msgid "Syntax: tomb [options] command [arguments]"
-msgstr ""
+msgstr "Sintaxe: tomb [opções] comando [argumentos]"
 
 #: tomb:Commandline interaction:usage:614
 msgid "Commands:"
-msgstr ""
+msgstr "Comandos:"
 
 #: tomb:Commandline interaction:usage:616
 msgid " // Creation:"
-msgstr ""
+msgstr " // Criação:"
 
 #: tomb:Commandline interaction:usage:617
 msgid " dig     create a new empty TOMB file of size -s in MiB"
-msgstr ""
+msgstr " dig     cria um novo arquivo de TUMBA vazio de tamanho -s em MiB"
 
 #: tomb:Commandline interaction:usage:618
 msgid " forge   create a new KEY file and set its password"
-msgstr ""
+msgstr " forge   cria um novo arquivo de CHAVE e define sua senha"
 
 #: tomb:Commandline interaction:usage:619
 msgid " lock    installs a lock on a TOMB to use it with KEY"
-msgstr ""
+msgstr " lock    instala um cadeado em uma TUMBA para usá-lo com uma CHAVE"
 
 #: tomb:Commandline interaction:usage:621
 msgid " // Operations on tombs:"
-msgstr ""
+msgstr " // Operações sobre tumbas:"
 
 #: tomb:Commandline interaction:usage:622
 msgid " open    open an existing TOMB (-k KEY file or - for stdin)"
 msgstr ""
+" open    abre uma TUMBA existente (-k arquivo de CHAVE ou - para stdin)"
 
 #: tomb:Commandline interaction:usage:623
 msgid " index   update the search indexes of tombs"
-msgstr ""
+msgstr " index   atualiza os índices de busca de tumbas"
 
 #: tomb:Commandline interaction:usage:624
 msgid " search  looks for filenames matching text patterns"
 msgstr ""
+" search  procura nomes de arquivos com padrões de texto correspondentes"
 
 #: tomb:Commandline interaction:usage:625
 msgid " list    list of open TOMBs and information on them"
-msgstr ""
+msgstr " list    lista TUMBAS abertas e informações sobre elas"
 
 #: tomb:Commandline interaction:usage:626
 msgid " close   close a specific TOMB (or 'all')"
-msgstr ""
+msgstr " close   fecha uma TUMBA específica (ou todas: 'all')"
 
 #: tomb:Commandline interaction:usage:627
 msgid " slam    slam a TOMB killing all programs using it"
 msgstr ""
+" slam    fecha uma TUMBA matando todos os programas que a estejam usando"
 
 #: tomb:Commandline interaction:usage:629
 msgid " resize  resize a TOMB to a new size -s (can only grow)"
 msgstr ""
+" resize  redimensiona uma TUMBA para o novo tamanho -s (só pode aumentar)"
 
 #: tomb:Commandline interaction:usage:632
 msgid " // Operations on keys:"
-msgstr ""
+msgstr " // Operações sobre chaves:"
 
 #: tomb:Commandline interaction:usage:633
 msgid " passwd  change the password of a KEY (needs old pass)"
-msgstr ""
+msgstr " passwd  altera a senha de uma CHAVE (a antiga é necessária)"
 
 #: tomb:Commandline interaction:usage:634
 msgid " setkey  change the KEY locking a TOMB (needs old key and pass)"
 msgstr ""
+" setkey  altera a CHAVE de uma TUMBA (precisa da chave e senha antigas)"
 
 #: tomb:Commandline interaction:usage:637
 msgid " // Backup on paper:"
-msgstr ""
+msgstr " // Backup em papel:"
 
 #: tomb:Commandline interaction:usage:638
 msgid " engrave makes a QR code of a KEY to be saved on paper"
-msgstr ""
+msgstr " engrave cria um QR code de uma CHAVE para ser salvo em papel"
 
 #: tomb:Commandline interaction:usage:642
 msgid " // Steganography:"
-msgstr ""
+msgstr " // Esteganografia:"
 
 #: tomb:Commandline interaction:usage:643
 msgid " bury    hide a KEY inside a JPEG image (for use with -k)"
-msgstr ""
+msgstr " bury    esconde uma CHAVE dentro de uma imagem JPEG (para uso com -k)"
 
 #: tomb:Commandline interaction:usage:644
 msgid " exhume  extract a KEY from a JPEG image (prints to stdout)"
-msgstr ""
+msgstr " exhume  extrai uma CHAVE de uma imagem JPEG (imprime para stdout)"
 
 #: tomb:Commandline interaction:usage:647
 msgid "Options:"
-msgstr ""
+msgstr "Opções:"
 
 #: tomb:Commandline interaction:usage:649
 msgid " -s     size of the tomb file when creating/resizing one (in MiB)"
-msgstr ""
+msgstr " -s     tamanho do arquivo de tumba a criar/redimensionar (em MiB)"
 
 #: tomb:Commandline interaction:usage:650
 msgid " -k     path to the key to be used ('-k -' to read from stdin)"
-msgstr ""
+msgstr " -k     caminho para a chave a ser usada ('-k -' para ler de stdin)"
 
 #: tomb:Commandline interaction:usage:651
 msgid " -n     don't process the hooks found in tomb"
-msgstr ""
+msgstr " -n     não inicia os ganchos de execução encontrados na tumba"
 
 #: tomb:Commandline interaction:usage:652
 msgid " -o     options passed to commands: open, lock, forge (see man)"
-msgstr ""
+msgstr " -o     opções passadas aos comandos: open, lock, forge (veja man)"
 
 #: tomb:Commandline interaction:usage:653
 msgid " -f     force operation (i.e. even if swap is active)"
-msgstr ""
+msgstr " -f     força a operação (mesmo que a swap esteja ativa)"
 
 #: tomb:Commandline interaction:usage:655
 msgid " --kdf  forge keys armored against dictionary attacks"
-msgstr ""
+msgstr " --kdf  forja chaves protegidas contra ataques de dicionário"
 
 #: tomb:Commandline interaction:usage:659
 msgid " -h     print this help"
-msgstr ""
+msgstr " -h     imprime essa ajuda"
 
 #: tomb:Commandline interaction:usage:660
 msgid " -v     print version, license and list of available ciphers"
-msgstr ""
+msgstr " -v     imprime versão, licença e lista de cifras disponíveis"
 
 #: tomb:Commandline interaction:usage:661
 msgid " -q     run quietly without printing informations"
-msgstr ""
+msgstr " -q     executa em silêncio sem imprimir informações"
 
 #: tomb:Commandline interaction:usage:662
 msgid " -D     print debugging information at runtime"
-msgstr ""
+msgstr " -D     imprime informações de depuração em tempo de execução"
 
 #: tomb:Commandline interaction:usage:664
 msgid "For more informations on Tomb read the manual: man tomb"
-msgstr ""
+msgstr "Para mais informações sobre Tomb, leia o manual: man tomb"
 
 #: tomb:Commandline interaction:usage:665
 msgid "Please report bugs on <http://github.com/dyne/tomb/issues>."
-msgstr ""
+msgstr "Reporte bugs em <http://github.com/dyne/tomb/issues>."
 
 #: tomb:Commandline interaction:_ensure_dependencies:800
 msgid "Missing required dependency ::1 command::.  Please install it."
-msgstr ""
+msgstr "Falta uma dependência necessária::1 comando::.  Por favor, instale-a."
 
 #: tomb:Key operations:is_valid_key:837
 msgid "cleartext key from stdin selected: this is unsafe."
 msgstr ""
+"chave de texto não criptografado selecionada de stdin: isso não é seguro."
 
 #: tomb:Key operations:is_valid_key:838
 msgid "please use --unsafe if you really want to do this."
-msgstr ""
+msgstr "por favor, use --unsafe se você realmente quiser fazer isso."
 
 #: tomb:Key operations:is_valid_key:840
 msgid "received key in cleartext from stdin (unsafe mode)"
-msgstr ""
+msgstr "chave recebida em texto não criptografado de stdin (modo inseguro)"
 
 #: tomb:Key operations:is_valid_key:844
 msgid "is_valid_key() called without an argument."
-msgstr ""
+msgstr "função is_valid_key() chamada sem um argumento."
 
 #: tomb:Key operations:is_valid_key:852
 msgid "Key is an image, it might be valid."
-msgstr ""
+msgstr "A chave é uma imagem, pode ser válida."
 
 #: tomb:Key operations:is_valid_key:856
 msgid "Key is valid."
-msgstr ""
+msgstr "A chave é valida."
 
 #: tomb:Key operations:recover_key:866
 msgid "Attempting key recovery."
-msgstr ""
+msgstr "Tentativa de recuperação de chave."
 
 #: tomb:Key operations:_load_key:890
 msgid "This operation requires a key file to be specified using the -k option."
 msgstr ""
+"Esta operação requer que um arquivo de chave seja especificado usando a "
+"opção -k."
 
 #: tomb:Key operations:_load_key:894
 msgid "Waiting for the key to be piped from stdin... "
-msgstr ""
+msgstr "Aguardando a chave ser canalizada de stdin... "
 
 #: tomb:Key operations:_load_key:905
 msgid "Key not found, specify one using -k."
-msgstr ""
+msgstr "Chave não encontrada, especifique uma usando -k."
 
 #: tomb:Key operations:_load_key:919
-msgid "The key seems invalid or its format is not known by this version of Tomb."
+msgid ""
+"The key seems invalid or its format is not known by this version of Tomb."
 msgstr ""
+"A chave parece inválida ou seu formato não é conhecido por esta versão do "
+"Tomb."
 
 #: tomb:Key operations:get_lukskey:988
 msgid "Unlocking KDF key protection (::1 kdf::)"
-msgstr ""
+msgstr "Desbloqueando a proteção de chave KDF (::1 kdf::)"
 
 #: tomb:Key operations:get_lukskey:995
 msgid "No suitable program for KDF ::1 program::."
-msgstr ""
+msgstr "Nenhum programa adequado para KDF ::1 programa::."
 
 #: tomb:Key operations:ask_key_password:1021
 msgid "Internal error: ask_key_password() called before _load_key()."
-msgstr ""
+msgstr "Erro interno: função ask_key_password() chamada antes de _load_key()."
 
 #: tomb:Key operations:ask_key_password:1027
 msgid "A password is required to use key ::1 key::"
-msgstr ""
+msgstr "Uma senha é necessária para usar a chave ::1 chave::"
 
 #: tomb:Key operations:ask_key_password:1039
 msgid "User aborted password dialog."
-msgstr ""
+msgstr "Diálogo de senha abortado pelo usuário."
 
 #: tomb:Key operations:ask_key_password:1046
 msgid "Password OK."
-msgstr ""
+msgstr "Senha OK."
 
 #: tomb:Key operations:change_passwd:1083
 msgid "Commanded to change password for tomb key ::1 key::"
-msgstr ""
+msgstr "Ordenado a alterar a senha da chave da chave tumba ::1 chave::"
 
 #: tomb:Key operations:change_passwd:1095
 msgid "No valid password supplied."
-msgstr ""
+msgstr "Nenhuma senha válida fornecida."
 
 #: tomb:Key operations:change_passwd:1097
 msgid "Changing password for ::1 key file::"
-msgstr ""
+msgstr "Alterando a senha para ::1 arquivo de chave::"
 
 #: tomb:Key operations:change_passwd:1110
 msgid "Error: the newly generated keyfile does not seem valid."
-msgstr ""
+msgstr "Erro: o arquivo de chave recém-criado não parece válido."
 
 #: tomb:Key operations:change_passwd:1114
 msgid "Your passphrase was successfully updated."
-msgstr ""
+msgstr "Sua senha foi atualizada com sucesso."
 
 #: tomb:Key operations:gen_key:1136
 msgid "User aborted."
-msgstr ""
+msgstr "Usuário abortou."
 
 #: tomb:Key operations:gen_key:1139
 msgid "You set empty password, which is not possible."
-msgstr ""
+msgstr "Você definiu uma senha vazia, o que não é possível."
 
 #: tomb:Key operations:gen_key:1167
-msgid "Wrong argument for --kdf: must be an integer number (iteration seconds)."
+msgid ""
+"Wrong argument for --kdf: must be an integer number (iteration seconds)."
 msgstr ""
+"Argumento incorreto para --kdf: deve ser um número inteiro (segundos de "
+"iteração)."
 
 #: tomb:Key operations:gen_key:1168
-msgid "Depending on the speed of machines using this tomb, use 1 to 10, or more"
+msgid ""
+"Depending on the speed of machines using this tomb, use 1 to 10, or more"
 msgstr ""
+"Dependendo da velocidade das máquinas que usam tomb, use de 1 a 10, ou mais"
 
 #: tomb:Key operations:gen_key:1174
 msgid "Using KDF, iteration time: ::1 microseconds::"
-msgstr ""
+msgstr "Usando KDF, tempo de iteração: ::1 microssegundos::"
 
 #: tomb:Key operations:gen_key:1175
 msgid "generating salt"
-msgstr ""
+msgstr "gerando salt"
 
 #: tomb:Key operations:gen_key:1177
 msgid "calculating iterations"
-msgstr ""
+msgstr "calculando iterações"
 
 #: tomb:Key operations:gen_key:1179
 msgid "encoding the password"
-msgstr ""
+msgstr "codificando a senha"
 
 #: tomb:Key operations:list_gnupg_ciphers:1215
 msgid "gpg (GnuPG) is not found, Tomb cannot function without it."
-msgstr ""
+msgstr "gpg (GnuPG) não foi encontrado, o Tomb não pode funcionar sem ele."
 
 #: tomb:Key operations:bury_key:1236
 msgid "Encode failed: ::1 image file:: is not a jpeg image."
-msgstr ""
+msgstr "Falha na codificação: ::1 arquivo de imagem:: não é uma imagem jpeg."
 
 #: tomb:Key operations:bury_key:1240
 msgid "Encoding key ::1 tomb key:: inside image ::2 image file::"
 msgstr ""
+"Codificando chave ::1 chave da tumba:: dentro da imagem ::2 arquivo de "
+"imagem::"
 
 #: tomb:Key operations:bury_key:1241
 msgid "Please confirm the key password for the encoding"
-msgstr ""
+msgstr "Por favor, confirme a senha da chave para a codificação"
 
 #: tomb:Key operations:bury_key:1257
 msgid "Wrong password supplied."
-msgstr ""
+msgstr "Foi fornecida uma senha incorreta."
 
 #: tomb:Key operations:bury_key:1258
 msgid "You shall not bury a key whose password is unknown to you."
-msgstr ""
+msgstr "Você não deve enterrar uma chave cuja senha você desconheça."
 
 #: tomb:Key operations:bury_key:1269
 msgid "Encoding error: steghide reports problems."
-msgstr ""
+msgstr "Erro de codificação: steghide relata problemas."
 
 #: tomb:Key operations:bury_key:1272
 msgid "Tomb key encoded succesfully into image ::1 image file::"
 msgstr ""
+"Chave de tumba codificada com sucesso na imagem ::1 arquivo de imagem::"
 
 #: tomb:Key operations:exhume_key:1284
 msgid "Exhume failed, no image specified"
-msgstr ""
+msgstr "Exumação falhou, nenhuma imagem especificada"
 
 #: tomb:Key operations:exhume_key:1294
 msgid "Exhume failed, image file not found: ::1 image file::"
 msgstr ""
+"Exumação falhou, arquivo de imagem não encontrado: ::1 arquivo de imagem::"
 
 #: tomb:Key operations:exhume_key:1296
 msgid "Exhume failed: ::1 image file:: is not a jpeg image."
-msgstr ""
+msgstr "Exumação falhou: ::1 arquivo de imagem:: não é uma imagem jpeg."
 
 #: tomb:Key operations:exhume_key:1303
 msgid "Wrong password or no steganographic key found"
-msgstr ""
+msgstr "Senha errada ou nenhuma chave esteganográfica encontrada"
 
 #: tomb:Key operations:exhume_key:1314
 msgid "printing exhumed key on stdout"
-msgstr ""
+msgstr "imprimindo chave exumada em stdout"
 
 #: tomb:Key operations:exhume_key:1318
 msgid "File exists: ::1 tomb key::"
-msgstr ""
+msgstr "O arquivo existe: ::1 chave da tumba::"
 
 #: tomb:Key operations:exhume_key:1320
 msgid "Use of --force selected: overwriting."
-msgstr ""
+msgstr "Uso de --force selecionado: sobrescrevendo."
 
 #: tomb:Key operations:exhume_key:1323
 msgid "Make explicit use of --force to overwrite."
-msgstr ""
+msgstr "Faça uso explícito de --force para sobrescrever."
 
 #: tomb:Key operations:exhume_key:1324
 msgid "Refusing to overwrite file. Operation aborted."
-msgstr ""
+msgstr "Recusando-se a sobrescrever o arquivo. Operação abortada."
 
 #: tomb:Key operations:exhume_key:1327
 msgid "Trying to exhume a key out of image ::1 image file::"
-msgstr ""
+msgstr "Tentando exumar uma chave da imagem ::1 arquivo de imagem::"
 
 #: tomb:Key operations:exhume_key:1348
 msgid "Key succesfully exhumed to ::1 key::."
-msgstr ""
+msgstr "Chave exumada com sucesso para ::1 chave::."
 
 #: tomb:Key operations:exhume_key:1350
 msgid "Nothing found in ::1 image file::"
-msgstr ""
+msgstr "Nada encontrado em ::1 arquivo de imagem::"
 
 #: tomb:Key operations:engrave_key:1365
 msgid "Rendering a printable QRCode for key: ::1 tomb key file::"
 msgstr ""
+"Renderizando um QRCode imprimível para a chave: ::1 arquivo de chave da "
+"tumba::"
 
 #: tomb:Key operations:engrave_key:1370
 msgid "QREncode reported an error."
-msgstr ""
+msgstr "QREncode relatou um erro."
 
 #: tomb:Key operations:engrave_key:1372
 msgid "Operation successful:"
-msgstr ""
+msgstr "Operação bem sucedida:"
 
 #: tomb:Create:dig_tomb:1405
 msgid "Commanded to dig tomb ::1 tomb path::"
-msgstr ""
+msgstr "Ordenado a a cavar a tumba ::1 caminho da tumba::"
 
 #: tomb:Create:dig_tomb:1407
 msgid "Missing path to tomb"
-msgstr ""
+msgstr "Falta o caminho para a tumba"
 
 #: tomb:Create:dig_tomb:1408
 msgid "Size argument missing, use -s"
-msgstr ""
+msgstr "Argumento de tamanho ausente, use -s"
 
 #: tomb:Create:dig_tomb:1409
 msgid "Size must be an integer (mebibytes)"
-msgstr ""
+msgstr "O tamanho deve ser um número inteiro (mebibytes)"
 
 #: tomb:Create:dig_tomb:1410
 msgid "Tombs can't be smaller than 10 mebibytes"
-msgstr ""
+msgstr "Tumbas não podem ser menores que 10 mebibytes"
 
 #: tomb:Create:dig_tomb:1415
 msgid "A tomb exists already. I'm not digging here:"
-msgstr ""
+msgstr "Já existe uma tumba. Eu não vou cavar aqui:"
 
 #: tomb:Create:dig_tomb:1420
 msgid "Creating a new tomb in ::1 tomb path::"
-msgstr ""
+msgstr "Criando uma nova tumba em ::1 caminho da tumba::"
 
 #: tomb:Create:dig_tomb:1422
 msgid "Generating ::1 tomb file:: of ::2 size::MiB"
-msgstr ""
+msgstr "Gerando ::1 arquivo tumba:: de ::2 tamanho::MiB"
 
 #: tomb:Create:dig_tomb:1427
 msgid "Error creating the tomb ::1 tomb path::"
-msgstr ""
+msgstr "Erro ao criar a tumba ::1 caminho da tumba::"
 
 #: tomb:Create:dig_tomb:1442
 msgid "Done digging ::1 tomb name::"
-msgstr ""
+msgstr "Concluída a escavação de ::1 nome da tumba::"
 
 #: tomb:Create:dig_tomb:1443
 msgid "Your tomb is not yet ready, you need to forge a key and lock it:"
 msgstr ""
+"Sua tumba ainda não está pronta, você precisa forjar uma chave e trancá-la:"
 
 #: tomb:Create:dig_tomb:1444
 msgid "tomb forge ::1 tomb path::.key"
-msgstr ""
+msgstr "tomb forge ::1 caminho da tumba::.key"
 
 #: tomb:Create:dig_tomb:1445
 msgid "tomb lock ::1 tomb path:: -k ::1 tomb path::.key"
-msgstr ""
+msgstr "tomb lock ::1 caminho da tumba:: -k ::1 caminho da tumba::.key"
 
 #: tomb:Create:forge_key:1466
 msgid "A filename needs to be specified using -k to forge a new key."
 msgstr ""
+"Um nome de arquivo precisa ser especificado usando -k para forjar uma nova "
+"chave."
 
 #: tomb:Create:forge_key:1468
 msgid "Commanded to forge key ::1 key::"
-msgstr ""
+msgstr "Ordenado a forjar chave ::1 chave::"
 
 #: tomb:Create:forge_key:1480
 msgid "Forging this key would overwrite an existing file. Operation aborted."
 msgstr ""
+"Forjar essa chave substituiria um arquivo existente. Operação abortada."
 
 #: tomb:Create:forge_key:1484
 msgid "Cannot generate encryption key."
-msgstr ""
+msgstr "Não é possível gerar a chave de criptografia."
 
 #: tomb:Create:forge_key:1492
 msgid "Commanded to forge key ::1 key:: with cipher algorithm ::2 algorithm::"
 msgstr ""
+"Ordenado a forjar a chave ::1 chave:: com algoritmo de cifra ::2 algoritmo::"
 
 #: tomb:Create:forge_key:1501
 msgid "This operation takes time, keep using this computer on other tasks,"
 msgstr ""
+"Esta operação leva tempo. Continue usando este computador em outras tarefas,"
 
 #: tomb:Create:forge_key:1502
 msgid "once done you will be asked to choose a password for your tomb."
 msgstr ""
+"uma vez feito isso, você será solicitado a escolher uma senha para a sua "
+"tumba."
 
 #: tomb:Create:forge_key:1503
 msgid "To make it faster you can move the mouse around."
-msgstr ""
+msgstr "Para tornar mais rápido, você pode mover o mouse."
 
 #: tomb:Create:forge_key:1504
 msgid "If you are on a server, you can use an Entropy Generation Daemon."
 msgstr ""
+"Se você estiver em um servidor, poderá usar um Entropy Generation Daemon."
 
 #: tomb:Create:forge_key:1518
 msgid "Choose the  password of your key: ::1 tomb key::"
-msgstr ""
+msgstr "Escolha a senha para a sua chave: ::1 chave da tumba::"
 
 #: tomb:Create:forge_key:1519
 msgid "(You can also change it later using 'tomb passwd'.)"
-msgstr ""
+msgstr "(Você também pode alterá-la mais tarde usando 'tomb passwd'.)"
 
 #: tomb:Create:forge_key:1537
 msgid "The key does not seem to be valid."
-msgstr ""
+msgstr "A chave não parece ser válida."
 
 #: tomb:Create:forge_key:1538
 msgid "Dumping contents to screen:"
-msgstr ""
+msgstr "Despejando conteúdo para a tela:"
 
 #: tomb:Create:forge_key:1546
 msgid "Done forging ::1 key file::"
-msgstr ""
+msgstr "Concluída a forja de ::1 arquivo de chave::"
 
 #: tomb:Create:forge_key:1547
 msgid "Your key is ready:"
-msgstr ""
+msgstr "Sua chave está pronta:"
 
 #: tomb:Create:lock_tomb_with_key:1567
 msgid "No tomb specified for locking."
-msgstr ""
+msgstr "Nenhuma tumba foi especificada para trancar."
 
 #: tomb:Create:lock_tomb_with_key:1568
 msgid "Usage: tomb lock file.tomb file.tomb.key"
-msgstr ""
+msgstr "Uso: tomb lock arquivo.tomb -k arquivo.tomb.key"
 
 #: tomb:Create:lock_tomb_with_key:1574
 msgid "Commanded to lock tomb ::1 tomb file::"
-msgstr ""
+msgstr "Ordenado a trancar tumba ::1 arquivo tumba::"
 
 #: tomb:Create:lock_tomb_with_key:1577
 msgid "There is no tomb here. You have to dig it first."
-msgstr ""
+msgstr "Não há nenhuma tumba aqui. Você tem que cavar primeiro."
 
 #: tomb:Create:lock_tomb_with_key:1586
 msgid "Checking if the tomb is empty (we never step on somebody else's bones)."
 msgstr ""
+"Verificar se a tumba está vazia (não se pisa nos ossos de outra pessoa)."
 
 #: tomb:Create:lock_tomb_with_key:1590
 msgid "The tomb was already locked with another key."
-msgstr ""
+msgstr "A tumba já estava trancada com outra chave."
 
 #: tomb:Create:lock_tomb_with_key:1591
-msgid "Operation aborted. I cannot lock an already locked tomb. Go dig a new one."
+msgid ""
+"Operation aborted. I cannot lock an already locked tomb. Go dig a new one."
 msgstr ""
+"Operação abortada. Não posso trancar uma tumba já trancada. Vá cavar outra."
 
 #: tomb:Create:lock_tomb_with_key:1593
 msgid "Fine, this tomb seems empty."
-msgstr ""
+msgstr "Tudo bem, esta tumba parece vazia."
 
 #: tomb:Create:lock_tomb_with_key:1601
 msgid "Locking using cipher: ::1 cipher::"
-msgstr ""
+msgstr "Fechando usando a cifra: ::1 cifra::"
 
 #: tomb:Create:lock_tomb_with_key:1613
 msgid "Locking ::1 tomb file:: with ::2 tomb key file::"
-msgstr ""
+msgstr "Trancando ::1 arquivo de tumba:: com ::2 arquivo de chave de tumba::"
 
 #: tomb:Create:lock_tomb_with_key:1615
 msgid "Formatting Luks mapped device."
-msgstr ""
+msgstr "Formatando o dispositivo mapeado Luks."
 
 #: tomb:Create:lock_tomb_with_key:1620
 msgid "cryptsetup luksFormat returned an error."
-msgstr ""
+msgstr "cryptsetup luksFormat retornou um erro."
 
 #: tomb:Create:lock_tomb_with_key:1625
 msgid "cryptsetup luksOpen returned an error."
-msgstr ""
+msgstr "cryptsetup luksOpen retornou um erro."
 
 #: tomb:Create:lock_tomb_with_key:1628
 msgid "Formatting your Tomb with Ext3/Ext4 filesystem."
-msgstr ""
+msgstr "Formatando sua tumba com o sistema de arquivos Ext3/Ext4."
 
 #: tomb:Create:lock_tomb_with_key:1632
 msgid "Tomb format returned an error."
-msgstr ""
+msgstr "A formatação da tumba retornou um erro."
 
 #: tomb:Create:lock_tomb_with_key:1633
 msgid "Your tomb ::1 tomb file:: may be corrupted."
-msgstr ""
+msgstr "Sua tumba ::1 arquivo de tumba:: pode estar corrompida."
 
 #: tomb:Create:lock_tomb_with_key:1638
 msgid "Done locking ::1 tomb name:: using Luks dm-crypt ::2 cipher::"
 msgstr ""
+"Trancamento concluído ::1 nome da tumba:: usando Luks dm-crypt ::2 cifra::"
 
 #: tomb:Create:lock_tomb_with_key:1639
-msgid "Your tomb is ready in ::1 tomb path:: and secured with key ::2 tomb key::"
+msgid ""
+"Your tomb is ready in ::1 tomb path:: and secured with key ::2 tomb key::"
 msgstr ""
+"Sua tumba está pronta em ::1 caminho da tumba:: e protegida com a chave ::2 "
+"chave da tumba::"
 
 #: tomb:Create:change_tomb_key:1649
 msgid "Commanded to reset key for tomb ::1 tomb path::"
-msgstr ""
+msgstr "Ordenado a redefinir a chave para a tumba ::1 caminho da tumba::"
 
 #: tomb:Create:change_tomb_key:1652
 msgid "Command 'setkey' needs two arguments: the old key file and the tomb."
 msgstr ""
+"O comando 'setkey' precisa de dois argumentos: o arquivo de chave antigo e a "
+"tumba."
 
 #: tomb:Create:change_tomb_key:1653
 msgid "I.e:  tomb -k new.tomb.key old.tomb.key secret.tomb"
-msgstr ""
+msgstr "I.e:  tomb -k nova.tomb.key velha.tomb.key secret.tomb"
 
 #: tomb:Create:change_tomb_key:1654
 msgid "Execution aborted."
-msgstr ""
+msgstr "Execução abortada."
 
 #: tomb:Create:change_tomb_key:1667
 msgid "Not a valid LUKS encrypted volume: ::1 volume::"
-msgstr ""
+msgstr "Não é um volume criptografado LUKS válido: ::1 volume::"
 
 #: tomb:Create:change_tomb_key:1675
 msgid "Changing lock on tomb ::1 tomb name::"
-msgstr ""
+msgstr "Mudando a fechadura da tumba ::1 nome da tumba::"
 
 #: tomb:Create:change_tomb_key:1676
 msgid "Old key: ::1 old key::"
-msgstr ""
+msgstr "Chave antiga: ::1 chave antiga::"
 
 #: tomb:Create:change_tomb_key:1692
 msgid "No valid password supplied for the old key."
-msgstr ""
+msgstr "Não foi fornecida uma senha válida para a chave antiga."
 
 #: tomb:Create:change_tomb_key:1698
 msgid "Unexpected error in luksOpen."
-msgstr ""
+msgstr "Erro inesperado no luksOpen."
 
 #: tomb:Create:change_tomb_key:1702
 msgid "New key: ::1 key file::"
-msgstr ""
+msgstr "Nova chave: ::1 arquivo de chave::"
 
 #: tomb:Create:change_tomb_key:1712
 msgid "No valid password supplied for the new key."
-msgstr ""
+msgstr "Não foi fornecida uma senha válida para a nova chave."
 
 #: tomb:Create:change_tomb_key:1721
 msgid "Unexpected error in luksChangeKey."
-msgstr ""
+msgstr "Erro inesperado em luksChangeKey."
 
 #: tomb:Create:change_tomb_key:1723
 msgid "Unexpected error in luksClose."
-msgstr ""
+msgstr "Erro inesperado em luksClose."
 
 #: tomb:Create:change_tomb_key:1725
-msgid "Succesfully changed key for tomb: ::1 tomb file::"
-msgstr ""
+msgid "Successfully changed key for tomb: ::1 tomb file::"
+msgstr "Chave alterada com sucesso para a tumba: ::1 arquivo da tumba::"
 
 #: tomb:Create:change_tomb_key:1726
 msgid "The new key is: ::1 new key::"
-msgstr ""
+msgstr "A nova chave é: ::1 nova chave::"
 
 #: tomb:Open:mount_tomb:1738
 msgid "No tomb name specified for opening."
-msgstr ""
+msgstr "Não foi especificada uma tumba para abrir."
 
 #: tomb:Open:mount_tomb:1740
 msgid "Commanded to open tomb ::1 tomb name::"
-msgstr ""
+msgstr "Ordenado a abrir a tumba ::1 nome da tumba::"
 
 #: tomb:Open:mount_tomb:1755
 msgid "Mountpoint not specified, using default: ::1 mount point::"
 msgstr ""
+"O ponto de montagem não foi especificado, usando o padrão: ::1 ponto de "
+"montagem::"
 
 #: tomb:Open:mount_tomb:1758
 msgid "Opening ::1 tomb file:: on ::2 mount point::"
-msgstr ""
+msgstr "Abrindo ::1 arquivo tumba:: em ::2 ponto de montagem::"
 
 #: tomb:Open:mount_tomb:1765
 msgid "::1 tomb file:: is not a valid Luks encrypted storage file."
 msgstr ""
+"::1 arquivo tumba:: não é um arquivo de armazenamento criptografado Luks "
+"válido."
 
 #: tomb:Open:mount_tomb:1767
 msgid "This tomb is a valid LUKS encrypted device."
-msgstr ""
+msgstr "Esta tumba é um dispositivo criptografado LUKS válido."
 
 #: tomb:Open:mount_tomb:1774
 msgid "Cipher is \"::1 cipher::\" mode \"::2 mode::\" hash \"::3 hash::\""
-msgstr ""
+msgstr "A cifra é \"::1 cifra::\" modo \"::2 modo::\" hash \"::3 hash::\""
 
 #: tomb:Open:mount_tomb:1781
-msgid "Multiple key slots are enabled on this tomb. Beware: there can be a backdoor."
+msgid ""
+"Multiple key slots are enabled on this tomb. Beware: there can be a backdoor."
 msgstr ""
+"Múltiplos slots de chave estão habilitados nesta tumba. Cuidado: pode haver "
+"um backdoor."
 
 #: tomb:Open:mount_tomb:1805
 msgid "Failure mounting the encrypted file."
-msgstr ""
+msgstr "Falha ao montar o arquivo criptografado."
 
 #: tomb:Open:mount_tomb:1815
 msgid "Success unlocking tomb ::1 tomb name::"
-msgstr ""
+msgstr "Tumba desbloqueada com sucesso: ::1 nome da tumba::"
 
 #: tomb:Open:mount_tomb:1818
 msgid "Checking filesystem via ::1::"
-msgstr ""
+msgstr "Verificando o sistema de arquivos via ::1::"
 
 #: tomb:Open:mount_tomb:1836
 msgid "Error mounting ::1 mapper:: on ::2 tombmount::"
-msgstr ""
+msgstr "Erro ao montar ::1 mapper:: em ::2 tombmount::"
 
 #: tomb:Open:mount_tomb:1838
 msgid "Are mount options '::1 mount options::' valid?"
-msgstr ""
+msgstr "As opções de montagem '::1 opções de montagem::' são válidas?"
 
 #: tomb:Open:mount_tomb:1843
 msgid "Cannot mount ::1 tomb name::"
-msgstr ""
+msgstr "Não é possível montar ::1 nome da tumba::"
 
 #: tomb:Open:mount_tomb:1850
 msgid "Success opening ::1 tomb file:: on ::2 mount point::"
-msgstr ""
+msgstr "Sucesso ao abrir ::1 arquivo tumba:: em ::2 ponto de montagem::"
 
 #: tomb:Open:mount_tomb:1866
 msgid "Last visit by ::1 user::(::2 tomb build::) from ::3 tty:: on ::4 host::"
 msgstr ""
+"Última visita de ::1 usuário::(::2 tomb build::) de ::3 tty:: em ::4 host::"
 
 #: tomb:Open:mount_tomb:1867
 msgid "on date ::1 date::"
-msgstr ""
+msgstr "na data ::1 data::"
 
 #: tomb:Open:exec_safe_bind_hooks:1915
 msgid "How pitiful!  A tomb, and no HOME."
-msgstr ""
+msgstr "Que pena!  Uma tumba e nenhuma HOME."
 
 #: tomb:Open:exec_safe_bind_hooks:1919
 msgid "Cannot exec bind hooks without a mounted tomb."
-msgstr ""
+msgstr "Não é possível executar bind-hooks sem uma tumba montada."
 
 #: tomb:Open:exec_safe_bind_hooks:1935
 msgid "bind-hooks file is broken"
-msgstr ""
+msgstr "arquivo bind-hooks está quebrado"
 
 #: tomb:Open:exec_safe_bind_hooks:1944
 msgid "bind-hooks map format: local/to/tomb local/to/$HOME"
-msgstr ""
+msgstr "formato de mapa de bind-hooks: local/para/tumba local/para/$HOME"
 
 #: tomb:Open:exec_safe_bind_hooks:1948
 msgid "bind-hooks map format: local/to/tomb local/to/$HOME.  Rolling back"
 msgstr ""
+"formato de mapa de bind-hooks: local/para/tumba local/para/$HOME.  Revertendo"
 
 #: tomb:Open:exec_safe_bind_hooks:1953
 msgid "bind-hook target not existent, skipping ::1 home::/::2 subdir::"
-msgstr ""
+msgstr "alvo de bind-hook não existe, ignorando ::1 home::/::2 subdir::"
 
 #: tomb:Open:exec_safe_bind_hooks:1955
-msgid "bind-hook source not found in tomb, skipping ::1 mount point::/::2 subdir::"
+msgid ""
+"bind-hook source not found in tomb, skipping ::1 mount point::/::2 subdir::"
 msgstr ""
+"origem do bind-hook não encontrada na tumba, ignorando ::1 ponto de "
+"montagem::/::2 subdiretório::"
 
 #: tomb:Open:exec_safe_post_hooks:1983
 msgid "Post hooks found, executing as user ::1 user name::."
-msgstr ""
+msgstr "Hooks encontrados, executando como usuário ::1 nome do usuário::."
 
 #: tomb:List:list_tombs:2002
 msgid "I can't see any ::1 status:: tomb, may they all rest in peace."
 msgstr ""
+"Não consigo ver nenhuma tumba ::1 status::, que todos descansem em paz."
 
 #: tomb:List:list_tombs:2039
 msgid "::1 tombname:: open on ::2 tombmount:: using ::3 tombfsopts::"
-msgstr ""
+msgstr "::1 nome da tumba:: aberta em ::2 tombmount:: usando ::3 tombfsopts::"
 
 #: tomb:List:list_tombs:2044
 msgid "::1 tombname:: open since ::2 tombsince::"
-msgstr ""
+msgstr "::1 nome da tumba:: aberta desde ::2 tombsince::"
 
 #: tomb:List:list_tombs:2047
-msgid "::1 tombname:: open by ::2 tombuser:: from ::3 tombtty:: on ::4 tombhost::"
+msgid ""
+"::1 tombname:: open by ::2 tombuser:: from ::3 tombtty:: on ::4 tombhost::"
 msgstr ""
+"::1 nome da tumba:: aberta por ::2 tombuser:: de ::3 tombtty:: em ::4 "
+"tombhost::"
 
 #: tomb:List:list_tombs:2051
-msgid "::1 tombname:: size ::2 tombtot:: of which ::3 tombused:: (::5 tombpercent::%) is used: ::4 tombavail:: free "
+msgid ""
+"::1 tombname:: size ::2 tombtot:: of which ::3 tombused:: (::5 tombpercent::"
+"%) is used: ::4 tombavail:: free "
 msgstr ""
+"::1 nome da tumba:: tamanho ::2 tombtot:: dos quais ::3 tombused:: (::5 "
+"tombpercent::%) em uso: ::4 tombavail:: livres "
 
 #: tomb:List:list_tombs:2055
 msgid "::1 tombname:: warning: your tomb is almost full!"
-msgstr ""
+msgstr "::1 nome da tumba:: aviso: sua tumba está quase cheia!"
 
 #: tomb:List:list_tombs:2061
 msgid "::1 tombname:: hooks ::2 hookname:: on ::3 hookdest::"
-msgstr ""
+msgstr "::1 nome da tumba:: hooks ::2 hookname:: em ::3 hookdest::"
 
 #: tomb:List:list_tomb_binds:2117
 msgid "Internal error: list_tomb_binds called without argument."
-msgstr ""
+msgstr "Erro interno: list_tomb_binds invocado sem argumento."
 
 #: tomb:Index and search:index_tombs:2160
 msgid "Cannot index tombs on this system: updatedb (mlocate) not installed."
 msgstr ""
+"Não é possível indexar tumbas neste sistema: updatedb (mlocate) não "
+"instalado."
 
 #: tomb:Index and search:index_tombs:2164
 msgid "Cannot use GNU findutils for index/search commands."
-msgstr ""
+msgstr "Não é possível usar GNU findutils para os comandos index/search."
 
 #: tomb:Index and search:index_tombs:2166
 msgid "Index command needs 'mlocate' to be installed."
-msgstr ""
+msgstr "O comando index precisa que 'mlocate' seja instalado."
 
 #: tomb:Index and search:index_tombs:2174
 msgid "There seems to be no open tomb engraved as [::1::]"
-msgstr ""
+msgstr "Parece não haver tumba aberta cinzelada como [::1::]"
 
 #: tomb:Index and search:index_tombs:2176
 msgid "I can't see any open tomb, may they all rest in peace."
-msgstr ""
+msgstr "Não vejo nenhuma tumba aberta, que todos descansem em paz."
 
 #: tomb:Index and search:index_tombs:2178
 msgid "Creating and updating search indexes."
-msgstr ""
+msgstr "Criando e atualização de índices de pesquisa."
 
 #: tomb:Index and search:index_tombs:2191
 msgid "Skipping ::1 tomb name:: (.noindex found)."
-msgstr ""
+msgstr "Ignorando ::1 nome da tumba:: (.noindex encontrado)."
 
 #: tomb:Index and search:index_tombs:2193
 msgid "Indexing ::1 tomb name:: filenames..."
-msgstr ""
+msgstr "Indexando ::1 nome da tumba:: nomes de arquivos..."
 
 #: tomb:Index and search:index_tombs:2198
 msgid "Indexing ::1 tomb name:: contents..."
-msgstr ""
+msgstr "Indexando ::1 nome da tumba:: conteúdo..."
 
 #: tomb:Index and search:index_tombs:2200
 msgid "Generating a new swish-e configuration file: ::1 swish conf::"
-msgstr ""
+msgstr "Gerando um novo arquivo de configuração swish-e: ::1 swish conf::"
 
 #: tomb:Index and search:index_tombs:2270
 msgid "Search index updated."
-msgstr ""
+msgstr "Índice de pesquisa atualizado."
 
 #: tomb:Index and search:search_tombs:2291
 msgid "Searching for: ::1::"
-msgstr ""
+msgstr "Procurando por: ::1::"
 
 #: tomb:Index and search:search_tombs:2299
 msgid "Searching filenames in tomb ::1 tomb name::"
-msgstr ""
+msgstr "Pesquisando arquivos na tumba ::1 nome da tumba::"
 
 #: tomb:Index and search:search_tombs:2301
 msgid "Matches found: ::1 matches::"
-msgstr ""
+msgstr "Correspondências encontradas: ::1 matches::"
 
 #: tomb:Index and search:search_tombs:2306
 msgid "Searching contents in tomb ::1 tomb name::"
-msgstr ""
+msgstr "Pesquisando conteúdo na tumba ::1 nome da tumba::"
 
 #: tomb:Index and search:search_tombs:2309
 msgid "Skipping tomb ::1 tomb name::: not indexed."
-msgstr ""
+msgstr "Ignorando tumba ::1 nome da tumba::: não indexada."
 
 #: tomb:Index and search:search_tombs:2310
 msgid "Run 'tomb index' to create indexes."
-msgstr ""
+msgstr "Execute 'tomb index' para criar índices."
 
 #: tomb:Index and search:search_tombs:2312
 msgid "Search completed."
-msgstr ""
+msgstr "Busca completada."
 
 #: tomb:Resize:resize_tomb:2323
 msgid "Commanded to resize tomb ::1 tomb name:: to ::2 size:: mebibytes."
 msgstr ""
+"Ordenado a redimensionar tumba ::1 nome da tumba:: para ::2 tamanho:: "
+"mebibytes."
 
 #: tomb:Resize:resize_tomb:2325
 msgid "No tomb name specified for resizing."
-msgstr ""
+msgstr "Nenhum nome de tumba especificado para redimensionamento."
 
 #: tomb:Resize:resize_tomb:2326
 msgid "Cannot find ::1::"
-msgstr ""
+msgstr "Não foi possível encontrar ::1::"
 
 #: tomb:Resize:resize_tomb:2330
 msgid "Aborting operations: new size was not specified, use -s"
-msgstr ""
+msgstr "Abortando operações: o novo tamanho não foi especificado, use -s"
 
 #: tomb:Resize:resize_tomb:2343
 msgid "Please close the tomb ::1 tomb name:: before trying to resize it."
 msgstr ""
+"Por favor, feche a tumba ::1 nome da tumba:: antes de tentar redimensioná-la."
 
 #: tomb:Resize:resize_tomb:2346
 msgid "You must specify the new size of ::1 tomb name::"
-msgstr ""
+msgstr "Você deve especificar o novo tamanho de ::1 nome da tumba::"
 
 #: tomb:Resize:resize_tomb:2348
 msgid "Size is not an integer."
-msgstr ""
+msgstr "O tamanho não é um número inteiro."
 
 #: tomb:Resize:resize_tomb:2360
 msgid "Error creating the extra resize ::1 size::, operation aborted."
 msgstr ""
+"Erro ao criar o redimensionamento extra ::1 tamanho::, operação abortada."
 
 #: tomb:Resize:resize_tomb:2367
 msgid "Tomb seems resized already, operating filesystem stretch"
-msgstr ""
+msgstr "A tumba já parece redimensionada, estendendo o sistema de arquivos"
 
 #: tomb:Resize:resize_tomb:2369
 msgid "The new size must be greater then old tomb size."
-msgstr ""
+msgstr "O novo tamanho deve ser maior que o antigo tamanho da tumba."
 
 #: tomb:Resize:resize_tomb:2387
 msgid "opening tomb"
-msgstr ""
+msgstr "abrindo tumba"
 
 #: tomb:Resize:resize_tomb:2392
 msgid "cryptsetup failed to resize ::1 mapper::"
-msgstr ""
+msgstr "cryptsetup falhou em redimensionar ::1 mapper::"
 
 #: tomb:Resize:resize_tomb:2395
 msgid "e2fsck failed to check ::1 mapper::"
-msgstr ""
+msgstr "e2fsck falhou em verificar ::1 mapper::"
 
 #: tomb:Resize:resize_tomb:2398
 msgid "resize2fs failed to resize ::1 mapper::"
-msgstr ""
+msgstr "resize2fs falhou em redimensionar ::1 mapper::"
 
 #: tomb:Close:umount_tomb:2422
 msgid "There is no open tomb to be closed."
-msgstr ""
+msgstr "Não há tumbas abertas para serem fechadas."
 
 #: tomb:Close:umount_tomb:2425
 msgid "Too many tombs mounted, please specify one (see tomb list)"
 msgstr ""
+"Muitas tumbas montadas, por favor, especifique uma (veja a lista de tumbas)"
 
 #: tomb:Close:umount_tomb:2426
 msgid "or issue the command 'tomb close all' to close them all."
-msgstr ""
+msgstr "ou execute o comando 'tomb close all' para fechar todas."
 
 #: tomb:Close:umount_tomb:2444
 msgid "Tomb not found: ::1 tomb file::"
-msgstr ""
+msgstr "Tumba não encontrada: ::1 arquivo de tumba::"
 
 #: tomb:Close:umount_tomb:2445
 msgid "Please specify an existing tomb."
-msgstr ""
+msgstr "Especifique uma tumba existente."
 
 #: tomb:Close:umount_tomb:2449
 msgid "Slamming tomb ::1 tomb name:: mounted on ::2 mount point::"
-msgstr ""
+msgstr "Batendo tumba ::1 nome da tumba:: montada em ::2 ponto de montagem::"
 
 #: tomb:Close:umount_tomb:2451
 msgid "Kill all processes busy inside the tomb."
-msgstr ""
+msgstr "Matar todos os processos ocupados dentro da tumba."
 
 #: tomb:Close:umount_tomb:2453
 msgid "Cannot slam the tomb ::1 tomb name::"
-msgstr ""
+msgstr "Não é possível bater (\"slam\") a tumba ::1 nome da tumba::"
 
 #: tomb:Close:umount_tomb:2455
 msgid "Closing tomb ::1 tomb name:: mounted on ::2 mount point::"
-msgstr ""
+msgstr "Fechando tumba ::1 nome da tumba:: montada em ::2 ponto de montagem::"
 
 #: tomb:Close:umount_tomb:2463
 msgid "Closing tomb bind hook: ::1 hook::"
-msgstr ""
+msgstr "Fechando bind-hook da tumba: ::1 hook::"
 
 #: tomb:Close:umount_tomb:2466
 msgid "Slamming tomb: killing all processes using this hook."
-msgstr ""
+msgstr "Batendo tumba: matando todos os processos usando este hook."
 
 #: tomb:Close:umount_tomb:2467
 msgid "Cannot slam the bind hook ::1 hook::"
-msgstr ""
+msgstr "Não é posível bater (\"slam\") o bind-hook ::1 hook::"
 
 #: tomb:Close:umount_tomb:2470
 msgid "Tomb bind hook ::1 hook:: is busy, cannot close tomb."
 msgstr ""
+"Bind-hook da tumba ::1 hook:: está ocupado, não é possível fechar a tumba."
 
 #: tomb:Close:umount_tomb:2481
 msgid "Tomb is busy, cannot umount!"
-msgstr ""
+msgstr "A tumba está ocupada, não é possível desmontar!"
 
 #: tomb:Close:umount_tomb:2492
 msgid "Error occurred in cryptsetup luksClose ::1 mapper::"
-msgstr ""
+msgstr "Ocorreu um erro no cryptsetup luksClose ::1 mapper::"
 
 #: tomb:Close:umount_tomb:2499
 msgid "Tomb ::1 tomb name:: closed: your bones will rest in peace."
-msgstr ""
+msgstr "Tumba ::1 nome da tumba:: fechada: seus ossos descansarão em paz."
 
 #: tomb:Main routine:main:2619
 msgid "Error parsing."
-msgstr ""
+msgstr "Erro ao analisar."
 
 #: tomb:Main routine:main:2629
 msgid "There's no such command \"::1 subcommand::\"."
-msgstr ""
+msgstr "O comando \"::1 subcomando::\" não existe."
 
 #: tomb:Main routine:main:2630
 msgid "Please try -h for help."
-msgstr ""
+msgstr "Por favor, tente -h para ajuda."
 
 #: tomb:Main routine:main:2642
 msgid "Some error occurred during option processing."
-msgstr ""
+msgstr "Ocorreu algum erro durante o processamento da opção."
 
 #: tomb:Main routine:main:2643
 msgid "See \"tomb help\" for more info."
-msgstr ""
+msgstr "Consulte \"tomb help\" para obter mais informações."
 
 #: tomb:Main routine:main:2655
 msgid "Unrecognized option ::1 arg:: for subcommand ::2 subcommand::"
-msgstr ""
+msgstr "Opção não reconhecida ::1 arg:: para subcomando ::2 subcomando::"
 
 #: tomb:Main routine:main:2671
-msgid "You specified option ::1 option::, which is DANGEROUS and should only be used for testing\nIf you really want so, add --unsafe"
+msgid ""
+"You specified option ::1 option::, which is DANGEROUS and should only be "
+"used for testing\n"
+"If you really want so, add --unsafe"
 msgstr ""
+"Você especificou a opção ::1 opção::, que é PERIGOSA e só deve ser usada "
+"para teste\n"
+"Se você realmente quiser, adicione --unsafe"
 
 #: tomb:Main routine:main:2705
-msgid "The create command is deprecated, please use dig, forge and lock instead."
+msgid ""
+"The create command is deprecated, please use dig, forge and lock instead."
 msgstr ""
+"O comando create está obsoleto, por favor, use dig, forge e lock em seu "
+"lugar."
 
 #: tomb:Main routine:main:2706
 msgid "For more informations see Tomb's manual page (man tomb)."
-msgstr ""
+msgstr "Para mais informações veja a página de manual do Tomb (man tomb)."
 
 #: tomb:Main routine:main:2740
 msgid "Resize2fs not installed: cannot resize tombs."
-msgstr ""
+msgstr "Resize2fs não instalado: não é possível redimensionar tumbas."
 
 #: tomb:Main routine:main:2766
 msgid "QREncode not installed: cannot engrave keys on paper."
-msgstr ""
+msgstr "QREncode não instalado: não é possível gravar chaves no papel."
 
 #: tomb:Main routine:main:2783
 msgid "Steghide not installed: cannot bury keys into images."
-msgstr ""
+msgstr "Steghide não instalado: não é possível enterrar chaves em imagens."
 
 #: tomb:Main routine:main:2790
 msgid "Steghide not installed: cannot exhume keys from images."
-msgstr ""
+msgstr "Steghide não instalado: não é possível exumar chaves de imagens."
 
 #: tomb:Main routine:main:2804
 msgid "Tomb ::1 version:: - a strong and gentle undertaker for your secrets"
 msgstr ""
+"Tomb ::1 versão:: - um agente funerário forte e gentil para os seus segredos"
 
 #: tomb:Main routine:main:2806
 msgid " Copyright (C) 2007-2017 Dyne.org Foundation, License GNU GPL v3+"
-msgstr ""
+msgstr " Copyright (C) 2007-2017 Dyne.org Foundation, Licença GNU GPL v3+"
 
 #: tomb:Main routine:main:2807
 msgid " This is free software: you are free to change and redistribute it"
 msgstr ""
+" Este é um software livre: você é livre para alterá-lo e redistribuí-lo"
 
 #: tomb:Main routine:main:2808
 msgid " For the latest sourcecode go to <http://dyne.org/software/tomb>"
 msgstr ""
+" Para obter o código-fonte mais atual, acesse <http://dyne.org/software/tomb>"
 
 #: tomb:Main routine:main:2813
 msgid " This source code is distributed in the hope that it will be useful,"
-msgstr ""
+msgstr " Este código-fonte é distribuído na esperança de que seja útil,"
 
 #: tomb:Main routine:main:2814
 msgid " but WITHOUT ANY WARRANTY; without even the implied warranty of"
-msgstr ""
+msgstr " mas SEM QUALQUER GARANTIA; nem mesmo a garantia implícita de"
 
 #: tomb:Main routine:main:2815
 msgid " MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
-msgstr ""
+msgstr " COMERCIABILIDADE ou ADEQUAÇÃO A UM DETERMINADO FIM."
 
 #: tomb:Main routine:main:2817
 msgid " When in need please refer to <http://dyne.org/support>."
-msgstr ""
+msgstr " Quando necessário, por favor consulte <http://dyne.org/support>."
 
 #: tomb:Main routine:main:2819
 msgid "System utils:"
-msgstr ""
+msgstr "Utilitários de sistema:"
 
 #: tomb:Main routine:main:2829
 msgid "Optional utils:"
-msgstr ""
+msgstr "Utilitários opcionais:"
 
 #: tomb:Main routine:main:2839
 msgid "Command \"::1 subcommand::\" not recognized."
-msgstr ""
+msgstr "Comando \"::1 subcomando::\" não reconhecido."
 
 #: tomb:Main routine:main:2840
 msgid "Try -h for help."
-msgstr ""
+msgstr "Tente -h para ajuda."

--- a/extras/translations/ru.po
+++ b/extras/translations/ru.po
@@ -1,16 +1,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Tomb the Crypto Undertaker\n"
-"PO-Revision-Date: 2022-05-18 19:14+0000\n"
-"Last-Translator: AHOHNMYC <lqwh2h2cwa@protonmail.com>\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2023-06-27 13:00-0300\n"
+"Last-Translator: Daniel Dias Rodrigues <danieldiasr@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/tomb/tomb/ru/>\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 4.13-dev\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #: tomb:Safety functions:_sudo:124
 msgid "[sudo] Enter password for user ::1 user:: to gain superuser privileges"
@@ -156,8 +156,7 @@ msgstr " lock    установить замок на ГРОБНИЦУ, испо
 msgid " // Operations on tombs:"
 msgstr " // Операции над гробницами:"
 
-#: tomb:Commandline
-#: interaction:usage:603
+#: tomb:Commandline interaction:usage:603
 msgid " open    open an existing TOMB"
 msgstr " open    открыть существующую ГРОБНИЦУ "
 
@@ -211,7 +210,7 @@ msgstr " // Стеганография:"
 
 #: tomb:Commandline interaction:usage:643
 msgid " bury    hide a KEY inside a JPEG image (for use with -k)"
-msgstr " bury   спрятать КЛЮЧ внутри изображения JPEG (для использования с -k)"
+msgstr " bury    спрятать КЛЮЧ внутри изображения JPEG (для использования с -k)"
 
 #: tomb:Commandline interaction:usage:644
 msgid " exhume  extract a KEY from a JPEG image (prints to stdout)"
@@ -221,8 +220,7 @@ msgstr " exhume  извлечь КЛЮЧ из изображения JPEG (вы�
 msgid "Options:"
 msgstr "Опции:"
 
-#: tomb:Commandline
-#: interaction:usage:630
+#: tomb:Commandline interaction:usage:630
 msgid " -s     size of the tomb file when creating/resizing one (in MB)"
 msgstr " -s     размер файла гробницы при создании/изменении размера (в Мб) "
 
@@ -272,9 +270,7 @@ msgstr "Пожалуйста, сообщайте о найденных ошиб�
 
 #: tomb:Commandline interaction:_ensure_dependencies:800
 msgid "Missing required dependency ::1 command::.  Please install it."
-msgstr ""
-"Отсутствует необходимая зависимость: ::1 command::.  Пожалуйста, установите "
-"ее."
+msgstr "Отсутствует необходимая зависимость: ::1 command::.  Пожалуйста, установите ее."
 
 #: tomb:Key operations:is_valid_key:837
 msgid "cleartext key from stdin selected: this is unsafe."
@@ -371,9 +367,7 @@ msgstr "Вы указали пустой пароль, так нельзя."
 #: tomb:Key operations:gen_key:1167
 #, fuzzy
 msgid "Wrong argument for --kdf: must be an integer number (iteration seconds)."
-msgstr ""
-"Неверный аргумент для --kdf: должно быть указано целое число (секунд "
-"итерации)."
+msgstr "Неверный аргумент для --kdf: должно быть указано целое число (секунд итерации)."
 
 #: tomb:Key operations:gen_key:1175
 msgid "generating salt"
@@ -745,9 +739,7 @@ msgstr "Шифр \"::1 cipher::\", режим \"::2 mode::\", хеш \"::3 hash:
 
 #: tomb:Open:mount_tomb:1781
 msgid "Multiple key slots are enabled on this tomb. Beware: there can be a backdoor."
-msgstr ""
-"Для этой гробницы разрешено использование нескольких ключей. Будь осторожен: "
-"там может быть задняя дверь."
+msgstr "Для этой гробницы разрешено использование нескольких ключей. Будь осторожен: там может быть задняя дверь."
 
 #: tomb:Open:mount_tomb:1805
 msgid "Failure mounting the encrypted file."
@@ -1046,16 +1038,16 @@ msgid "Unrecognized option ::1 arg:: for subcommand ::2 subcommand::"
 msgstr "Не распознана опция ::1 arg:: для подкоманды ::2 subcommand::"
 
 #: tomb:Main routine:main:2671
-msgid "You specified option ::1 option::, which is DANGEROUS and should only be used for testing\n"
+msgid ""
+"You specified option ::1 option::, which is DANGEROUS and should only be used for testing\n"
 "If you really want so, add --unsafe"
-msgstr "Вы указали опцию ::1 option::, которая ОПАСНА и должна быть использована только для тестирования\n"
+msgstr ""
+"Вы указали опцию ::1 option::, которая ОПАСНА и должна быть использована только для тестирования\n"
 "Если Вы и правда этого хотите, добавьте параметр --unsafe"
 
 #: tomb:Main routine:main:2705
 msgid "The create command is deprecated, please use dig, forge and lock instead."
-msgstr ""
-"Команда create устарела, пожалуйста, используйте dig, forge и lock вместо "
-"неё."
+msgstr "Команда create устарела, пожалуйста, используйте dig, forge и lock вместо неё."
 
 #: tomb:Main routine:main:2706
 msgid "For more informations see Tomb's manual page (man tomb)."
@@ -1135,9 +1127,7 @@ msgstr " dig     создать новый файл ГРОБНИЦЫ разме�
 
 #: tomb:Commandline interaction:usage:622
 msgid " open    open an existing TOMB (-k KEY file or - for stdin)"
-msgstr ""
-" open    открыть ГРОБНИЦУ (-k ФАЙЛ_КЛЮЧА или - для использования "
-"стандартного ввода)"
+msgstr " open    открыть ГРОБНИЦУ (-k ФАЙЛ_КЛЮЧА или - для использования стандартного ввода)"
 
 #: tomb:Commandline interaction:usage:649
 msgid " -s     size of the tomb file when creating/resizing one (in MiB)"
@@ -1149,9 +1139,7 @@ msgstr "Разблокировка защиты ключа KDF (::1 kdf::)"
 
 #: tomb:Key operations:gen_key:1168
 msgid "Depending on the speed of machines using this tomb, use 1 to 10, or more"
-msgstr ""
-"Используйте от 1 до 10 или более, в зависимости от скорости машин, "
-"использующих эту гробницу"
+msgstr "Используйте от 1 до 10 или более, в зависимости от скорости машин, использующих эту гробницу"
 
 #: tomb:Key operations:gen_key:1174
 msgid "Using KDF, iteration time: ::1 microseconds::"
@@ -1176,8 +1164,7 @@ msgstr "Формат привязки bind-hooks: local/to/tomb local/to/$HOME. 
 
 #: tomb:Resize:resize_tomb:2323
 msgid "Commanded to resize tomb ::1 tomb name:: to ::2 size:: mebibytes."
-msgstr ""
-"Приказано изменить размеры гробницы ::1 tomb name:: на ::2 size:: мебибайт."
+msgstr "Приказано изменить размеры гробницы ::1 tomb name:: на ::2 size:: мебибайт."
 
 #: tomb:Resize:resize_tomb:2367
 msgid "Tomb seems resized already, operating filesystem stretch"

--- a/extras/translations/tomb-2.10.pot
+++ b/extras/translations/tomb-2.10.pot
@@ -1,0 +1,1424 @@
+
+# Tomb - The Crypto Undertaker.
+# Copyright (C) 2007-2014 Dyne.org Foundation
+# Denis Roio <jaromil@dyne.org>, 2013.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"PO-Revision-Date: Tue Jun 27 15:23:46 2023\n"
+"Last-Translator: Denis Roio <jaromil@dyne.org>\n"
+"Language: English\n"
+"Language-Team: Tomb developers <crypto@lists.dyne.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: tomb:Safety functions:_sudo:120
+msgid "$pescmd executable not found"
+msgstr ""
+
+#: tomb:Safety functions:_sudo:124
+msgid "[sudo] Enter password for user ::1 user:: to gain superuser privileges"
+msgstr ""
+
+#: tomb:Safety functions:_sudo:131
+msgid "Super user execution not supported: ::1 sudo::"
+msgstr ""
+
+#: tomb:Safety functions:_whoami:236
+msgid "Failing to identify the user who is calling us"
+msgstr ""
+
+#: tomb:Safety functions:_tmp_create:272
+msgid "Fatal error creating the temporary directory: ::1 temp dir::"
+msgstr ""
+
+#: tomb:Safety functions:_tmp_create:280
+msgid "Fatal error setting the permission umask for temporary files"
+msgstr ""
+
+#: tomb:Safety functions:_tmp_create:283
+msgid "Someone is messing up with us trying to hijack temporary files."
+msgstr ""
+
+#: tomb:Safety functions:_tmp_create:287
+msgid "Fatal error creating a temporary file: ::1 temp file::"
+msgstr ""
+
+#: tomb:Safety functions:_ensure_safe_swap:398
+msgid "An active swap partition is detected..."
+msgstr ""
+
+#: tomb:Safety functions:_ensure_safe_swap:408
+msgid "Found zramswap with writeback enabled."
+msgstr ""
+
+#: tomb:Safety functions:_ensure_safe_swap:411
+msgid "Found zramswap without writeback to disk."
+msgstr ""
+
+#: tomb:Safety functions:_ensure_safe_swap:424
+msgid "The undertaker found that all swap partitions are encrypted. Good."
+msgstr ""
+
+#: tomb:Safety functions:_ensure_safe_swap:426
+msgid "This poses a security risk."
+msgstr ""
+
+#: tomb:Safety functions:_ensure_safe_swap:427
+msgid "You can deactivate all swap partitions using the command:"
+msgstr ""
+
+#: tomb:Safety functions:_ensure_safe_swap:428
+msgid " swapoff -a"
+msgstr ""
+
+#: tomb:Safety functions:_ensure_safe_swap:429
+msgid "[#163] I may not detect plain swaps on an encrypted volume."
+msgstr ""
+
+#: tomb:Safety functions:_ensure_safe_swap:430
+msgid "But if you want to proceed like this, use the -f (force) flag."
+msgstr ""
+
+#: tomb:Safety functions:_check_swap:449
+msgid "Operation aborted."
+msgstr ""
+
+#: tomb:Safety functions:ask_password:536
+msgid "Cannot find any pinentry-curses and no DISPLAY detected."
+msgstr ""
+
+#: tomb:Safety functions:ask_password:550
+msgid "Pinentry error: ::1 error::"
+msgstr ""
+
+#: tomb:Safety functions:ask_password:562
+msgid "Empty password"
+msgstr ""
+
+#: tomb:Safety functions:sphinx_get_password:587
+msgid "sphinx returns error: ::1 error::"
+msgstr ""
+
+#: tomb:Safety functions:sphinx_get_password:589
+msgid "Failed to retrieve actual password with sphinx."
+msgstr ""
+
+#: tomb:Safety functions:sphinx_get_password:592
+msgid "Both host and user have to be set to use sphinx"
+msgstr ""
+
+#: tomb:Safety functions:sphinx_set_password:623
+msgid "Failed to create password with sphinx"
+msgstr ""
+
+#: tomb:Safety functions:is_valid_tomb:636
+msgid "Tomb file is missing from arguments."
+msgstr ""
+
+#: tomb:Safety functions:is_valid_tomb:643
+msgid "Tomb file is not writable: ::1 tomb file::"
+msgstr ""
+
+#: tomb:Safety functions:is_valid_tomb:650
+msgid "Tomb file is not a regular file: ::1 tomb file::"
+msgstr ""
+
+#: tomb:Safety functions:is_valid_tomb:656
+msgid "Tomb file is empty (zero length): ::1 tomb file::"
+msgstr ""
+
+#: tomb:Safety functions:is_valid_tomb:662
+msgid "Tomb command failed: ::1 command name::"
+msgstr ""
+
+#: tomb:Safety functions:is_valid_tomb:667
+msgid "File is not yet a tomb: ::1 tomb file::"
+msgstr ""
+
+#: tomb:Safety functions:is_valid_tomb:687
+msgid "Tomb won't work without a TOMBNAME."
+msgstr ""
+
+#: tomb:Safety functions:is_valid_tomb:698
+msgid "Tomb file already in use: ::1 tombname::"
+msgstr ""
+
+#: tomb:Safety functions:is_valid_tomb:704
+msgid "Valid tomb file found: ::1 tomb path::"
+msgstr ""
+
+#: tomb:Safety functions:lo_mount:716
+msgid "Loop mount of volumes is not possible on this machine, this error"
+msgstr ""
+
+#: tomb:Safety functions:lo_mount:717
+msgid "often occurs on VPS and kernels that don't provide the loop module."
+msgstr ""
+
+#: tomb:Safety functions:lo_mount:718
+msgid "It is impossible to use Tomb on this machine under these conditions."
+msgstr ""
+
+#: tomb:Safety functions:lo_mount:726
+msgid "Loopback mount failed: ::1 path:: on ::2 loop::"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:762
+msgid "Syntax: tomb [options] command [arguments]"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:764
+msgid "Commands:"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:766
+msgid " // Creation:"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:767
+msgid " dig          create a new empty TOMB file of size -s in MiB"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:768
+msgid " forge        create a new KEY file and set its password"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:769
+msgid " lock         installs a lock on a TOMB to use it with KEY"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:771
+msgid " // Operations on tombs:"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:772
+msgid " open         open an existing TOMB (-k KEY file or - for stdin)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:773
+msgid " index        update the search indexes of tombs"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:774
+msgid " search       looks for filenames matching text patterns"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:775
+msgid " list         list of open TOMBs and information on them"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:776
+msgid " ps           list of running processes inside open TOMBs"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:777
+msgid " close        close a specific TOMB (or 'all')"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:778
+msgid " slam         slam a TOMB killing all programs using it"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:780
+msgid " resize       resize a TOMB to a new size -s (can only grow)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:783
+msgid " // Operations on keys:"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:784
+msgid " passwd       change the password of a KEY (needs old pass)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:785
+msgid " setkey       change the KEY locking a TOMB (needs old key and pass)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:788
+msgid " // Backup on paper:"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:789
+msgid " engrave      makes a QR code of a KEY to be saved on paper"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:793
+msgid " // Steganography:"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:795
+msgid " bury         hide a KEY inside a JPEG image (for use with -k)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:796
+msgid " exhume       extract a KEY from a JPEG image (prints to stdout)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:799
+msgid " cloak        transform a KEY into TEXT using CIPHER (for use with -k)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:802
+msgid " uncloak      extract a KEY from a TEXT using CIPHER (prints to stdout)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:806
+msgid "Options:"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:808
+msgid " -s           size of the tomb file when creating/resizing one (in MiB)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:809
+msgid " -k           path to the key to be used ('-k -' to read from stdin)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:810
+msgid " -n           don't launch the execution hooks found in tomb"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:811
+msgid " -p           preserve the ownership of all files in tomb"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:812
+msgid " -o           options passed to commands: open, lock, forge (see man)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:813
+msgid " -f           force operation (i.e. even if swap is active)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:814
+msgid " -g           use a GnuPG key to encrypt a tomb key"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:815
+msgid " -r           provide GnuPG recipients (separated by comma)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:816
+msgid " -R           provide GnuPG hidden recipients (separated by comma)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:817
+msgid " --sudo       super user exec alternative to sudo (doas or none)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:820
+msgid " --sphx-user  user associated with the key (for use with pitchforkedsphinx)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:821
+msgid " --sphx-host  host associated with the key (for use with pitchforkedsphinx)"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:825
+msgid " --kdf        forge keys armored against dictionary attacks"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:829
+msgid " -h           print this help"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:830
+msgid " -v           print version, license and list of available ciphers"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:831
+msgid " -q           run quietly without printing informations"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:832
+msgid " -D           print debugging information at runtime"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:834
+msgid "For more information on Tomb read the manual: man tomb"
+msgstr ""
+
+#: tomb:Commandline interaction:usage:835
+msgid "Please report bugs on <http://github.com/dyne/tomb/issues>."
+msgstr ""
+
+#: tomb:Commandline interaction:_ensure_dependencies:992
+msgid "Missing required dependency ::1 command::.  Please install it."
+msgstr ""
+
+#: tomb:Commandline interaction:_ensure_dependencies:1004
+msgid "No privilege escalation tool found, not even sudo"
+msgstr ""
+
+#: tomb:Key operations:is_valid_recipients:1052
+msgid "Not a valid GPG key ID: ::1 gpgid:: "
+msgstr ""
+
+#: tomb:Key operations:is_valid_recipients:1056
+msgid "The key ::1 gpgid:: is not trusted enough"
+msgstr ""
+
+#: tomb:Key operations:is_valid_key:1107
+msgid "cleartext key from stdin selected: this is unsafe."
+msgstr ""
+
+#: tomb:Key operations:is_valid_key:1108
+msgid "please use --unsafe if you really want to do this."
+msgstr ""
+
+#: tomb:Key operations:is_valid_key:1110
+msgid "received key in cleartext from stdin (unsafe mode)"
+msgstr ""
+
+#: tomb:Key operations:is_valid_key:1114
+msgid "is_valid_key() called without an argument."
+msgstr ""
+
+#: tomb:Key operations:is_valid_key:1122
+msgid "Key is an image, it might be valid."
+msgstr ""
+
+#: tomb:Key operations:is_valid_key:1128
+msgid "Key is missing KDF header."
+msgstr ""
+
+#: tomb:Key operations:is_valid_key:1134
+msgid "Key is valid."
+msgstr ""
+
+#: tomb:Key operations:recover_key:1144
+msgid "Attempting key recovery."
+msgstr ""
+
+#: tomb:Key operations:_load_key:1168
+msgid "This operation requires a key file to be specified using the -k option."
+msgstr ""
+
+#: tomb:Key operations:_load_key:1172
+msgid "Waiting for the key to be piped from stdin... "
+msgstr ""
+
+#: tomb:Key operations:_load_key:1183
+msgid "Key not found, specify one using -k."
+msgstr ""
+
+#: tomb:Key operations:_load_key:1198
+msgid "The key seems invalid or its format is not known by this version of Tomb."
+msgstr ""
+
+#: tomb:Key operations:gpg_decrypt:1229
+msgid "You set an invalid GPG ID."
+msgstr ""
+
+#: tomb:Key operations:get_lukskey:1281
+msgid "Unlocking KDF key protection (::1 kdf::)"
+msgstr ""
+
+#: tomb:Key operations:get_lukskey:1300
+msgid "No suitable program for KDF ::1 program::."
+msgstr ""
+
+#: tomb:Key operations:get_lukskey:1316
+msgid "User aborted password dialog."
+msgstr ""
+
+#: tomb:Key operations:ask_key_password:1340
+msgid "Internal error: ask_key_password() called before _load_key()."
+msgstr ""
+
+#: tomb:Key operations:ask_key_password:1352
+msgid "A password is required to use key ::1 key::"
+msgstr ""
+
+#: tomb:Key operations:ask_key_password:1371
+msgid "Password OK."
+msgstr ""
+
+#: tomb:Key operations:change_passwd:1419
+msgid "Commanded to change GnuPG key for tomb key ::1 key::"
+msgstr ""
+
+#: tomb:Key operations:change_passwd:1421
+msgid "Commanded to change password for tomb key ::1 key::"
+msgstr ""
+
+#: tomb:Key operations:change_passwd:1434
+msgid "No valid password supplied."
+msgstr ""
+
+#: tomb:Key operations:change_passwd:1437
+msgid "Changing GnuPG key for ::1 key file::"
+msgstr ""
+
+#: tomb:Key operations:change_passwd:1439
+msgid "Changing password for ::1 key file::"
+msgstr ""
+
+#: tomb:Key operations:change_passwd:1453
+msgid "Error: the newly generated keyfile does not seem valid."
+msgstr ""
+
+#: tomb:Key operations:change_passwd:1458
+msgid "Your GnuPG key was successfully changed"
+msgstr ""
+
+#: tomb:Key operations:change_passwd:1460
+msgid "Your passphrase was successfully updated."
+msgstr ""
+
+#: tomb:Key operations:gen_key:1511
+msgid "You are going to encrypt a tomb key with ::1 nrecipients:: recipient(s)."
+msgstr ""
+
+#: tomb:Key operations:gen_key:1512
+msgid "It is your responsibility to check these fingerprints."
+msgstr ""
+
+#: tomb:Key operations:gen_key:1513
+msgid "The fingerprints are:"
+msgstr ""
+
+#: tomb:Key operations:gen_key:1515
+msgid "	  `_gpg_fingerprint "
+msgstr ""
+
+#: tomb:Key operations:gen_key:1520
+msgid "No recipient specified, using default GPG key."
+msgstr ""
+
+#: tomb:Key operations:gen_key:1533
+msgid "User aborted."
+msgstr ""
+
+#: tomb:Key operations:gen_key:1536
+msgid "You set empty password, which is not possible."
+msgstr ""
+
+#: tomb:Key operations:gen_key:1577
+msgid "Wrong argument for --kdf: must be an integer number (iteration seconds)."
+msgstr ""
+
+#: tomb:Key operations:gen_key:1578
+msgid "Depending on the speed of machines using this tomb, use 1 to 10, or more"
+msgstr ""
+
+#: tomb:Key operations:gen_key:1589
+msgid "Using KDF, iteration time: ::1 microseconds::"
+msgstr ""
+
+#: tomb:Key operations:gen_key:1590
+msgid "generating salt"
+msgstr ""
+
+#: tomb:Key operations:gen_key:1592
+msgid "calculating iterations"
+msgstr ""
+
+#: tomb:Key operations:gen_key:1594
+msgid "encoding the password"
+msgstr ""
+
+#: tomb:Key operations:gen_key:1601
+msgid "Using KDF Argon2"
+msgstr ""
+
+#: tomb:Key operations:gen_key:1604
+msgid "memory used: 2^::1 kdfmemory::"
+msgstr ""
+
+#: tomb:Key operations:gen_key:1606
+msgid "kdf salt: ::1 kdfsalt::"
+msgstr ""
+
+#: tomb:Key operations:gen_key:1607
+msgid "kdf iterations: ::1 kdfiterations::"
+msgstr ""
+
+#: tomb:Key operations:bury_key:1667
+msgid "Encode failed: ::1 image file:: is not a jpeg image."
+msgstr ""
+
+#: tomb:Key operations:bury_key:1671
+msgid "Encoding key ::1 tomb key:: inside image ::2 image file::"
+msgstr ""
+
+#: tomb:Key operations:bury_key:1673
+msgid "Using GnuPG Key ID"
+msgstr ""
+
+#: tomb:Key operations:bury_key:1675
+msgid "Please confirm the key password for the encoding"
+msgstr ""
+
+#: tomb:Key operations:bury_key:1696
+msgid "Wrong password/GnuPG ID supplied."
+msgstr ""
+
+#: tomb:Key operations:bury_key:1697
+msgid "You shall not bury a key whose password is unknown to you."
+msgstr ""
+
+#: tomb:Key operations:bury_key:1737
+msgid "Encoding error: steghide reports problems."
+msgstr ""
+
+#: tomb:Key operations:bury_key:1740
+msgid "Tomb key encoded succesfully into image ::1 image file::"
+msgstr ""
+
+#: tomb:Key operations:exhume_key:1752
+msgid "Exhume failed, no image specified"
+msgstr ""
+
+#: tomb:Key operations:exhume_key:1765
+msgid "Exhume failed, image file not found: ::1 image file::"
+msgstr ""
+
+#: tomb:Key operations:exhume_key:1767
+msgid "Exhume failed: ::1 image file:: is not a jpeg image."
+msgstr ""
+
+#: tomb:Key operations:exhume_key:1774
+msgid "Wrong password or no steganographic key found"
+msgstr ""
+
+#: tomb:Key operations:exhume_key:1785
+msgid "printing exhumed key on stdout"
+msgstr ""
+
+#: tomb:Key operations:exhume_key:1789
+msgid "File exists: ::1 tomb key::"
+msgstr ""
+
+#: tomb:Key operations:exhume_key:1791
+msgid "Use of --force selected: overwriting."
+msgstr ""
+
+#: tomb:Key operations:exhume_key:1794
+msgid "Make explicit use of --force to overwrite."
+msgstr ""
+
+#: tomb:Key operations:exhume_key:1795
+msgid "Refusing to overwrite file. Operation aborted."
+msgstr ""
+
+#: tomb:Key operations:exhume_key:1798
+msgid "Trying to exhume a key out of image ::1 image file::"
+msgstr ""
+
+#: tomb:Key operations:exhume_key:1819
+msgid "Key succesfully exhumed to ::1 key::."
+msgstr ""
+
+#: tomb:Key operations:exhume_key:1821
+msgid "Nothing found in ::1 image file::"
+msgstr ""
+
+#: tomb:Key operations:cloakify_key:1843
+msgid "Encoding key ::1 tomb key:: using cipher ::2 cipher file::"
+msgstr ""
+
+#: tomb:Key operations:cloakify_key:1848
+msgid "printing cloaked key on stdout"
+msgstr ""
+
+#: tomb:Key operations:cloakify_key:1852
+msgid "File exists: ::1 output file::"
+msgstr ""
+
+#: tomb:Key operations:cloakify_key:1864
+msgid "Encoding error: cloakify reports problems."
+msgstr ""
+
+#: tomb:Key operations:cloakify_key:1867
+msgid "Tomb key encoded succesfully"
+msgstr ""
+
+#: tomb:Key operations:decloakify_key:1879
+msgid "Uncloak failed, no text file specified"
+msgstr ""
+
+#: tomb:Key operations:decloakify_key:1881
+msgid "Uncloak failed, no cipher file specified"
+msgstr ""
+
+#: tomb:Key operations:decloakify_key:1894
+msgid "Uncloak failed, text file not found: ::1 text file::"
+msgstr ""
+
+#: tomb:Key operations:decloakify_key:1897
+msgid "Uncloak failed, cipher file not found: ::1 cipher file::"
+msgstr ""
+
+#: tomb:Key operations:decloakify_key:1903
+msgid "printing uncloaked key on stdout"
+msgstr ""
+
+#: tomb:Key operations:decloakify_key:1923
+msgid "Key succesfully uncloaked to ::1 key::."
+msgstr ""
+
+#: tomb:Key operations:decloakify_key:1925
+msgid "Nothing found in ::1 text file::"
+msgstr ""
+
+#: tomb:Key operations:engrave_key:1942
+msgid "Rendering a printable QRCode for key: ::1 tomb key file::"
+msgstr ""
+
+#: tomb:Key operations:engrave_key:1947
+msgid "QREncode reported an error."
+msgstr ""
+
+#: tomb:Key operations:engrave_key:1949
+msgid "Operation successful:"
+msgstr ""
+
+#: tomb:Create:dig_tomb:1983
+msgid "Commanded to dig tomb ::1 tomb path::"
+msgstr ""
+
+#: tomb:Create:dig_tomb:1985
+msgid "Missing path to tomb"
+msgstr ""
+
+#: tomb:Create:dig_tomb:1986
+msgid "Size argument missing, use -s"
+msgstr ""
+
+#: tomb:Create:dig_tomb:1987
+msgid "Size must be an integer (mebibytes)"
+msgstr ""
+
+#: tomb:Create:dig_tomb:1988
+msgid "Tombs can't be smaller than 10 mebibytes"
+msgstr ""
+
+#: tomb:Create:dig_tomb:1991
+msgid "A tomb exists already. I'm not digging here:"
+msgstr ""
+
+#: tomb:Create:dig_tomb:1996
+msgid "Creating a new tomb in ::1 tomb path::"
+msgstr ""
+
+#: tomb:Create:dig_tomb:1997
+msgid "Generating ::1 tomb file:: of ::2 size::MiB"
+msgstr ""
+
+#: tomb:Create:dig_tomb:2001
+msgid "Error creating the tomb ::1 tomb path::"
+msgstr ""
+
+#: tomb:Create:dig_tomb:2011
+msgid "Done digging ::1 tomb name::"
+msgstr ""
+
+#: tomb:Create:dig_tomb:2012
+msgid "Your tomb is not yet ready, you need to forge a key and lock it:"
+msgstr ""
+
+#: tomb:Create:dig_tomb:2013
+msgid "tomb forge ::1 tomb path::.key"
+msgstr ""
+
+#: tomb:Create:dig_tomb:2014
+msgid "tomb lock ::1 tomb path:: -k ::1 tomb path::.key"
+msgstr ""
+
+#: tomb:Create:forge_key:2036
+msgid "A filename needs to be specified using -k to forge a new key."
+msgstr ""
+
+#: tomb:Create:forge_key:2038
+msgid "Commanded to forge key ::1 key::"
+msgstr ""
+
+#: tomb:Create:forge_key:2051
+msgid "Forging this key would overwrite an existing file. Operation aborted."
+msgstr ""
+
+#: tomb:Create:forge_key:2055
+msgid "Cannot generate encryption key."
+msgstr ""
+
+#: tomb:Create:forge_key:2063
+msgid "Commanded to forge key ::1 key:: with cipher algorithm ::2 algorithm::"
+msgstr ""
+
+#: tomb:Create:forge_key:2072
+msgid "This operation takes time. Keep using this computer on other tasks."
+msgstr ""
+
+#: tomb:Create:forge_key:2073
+msgid "Once done you will be asked to choose a password for your tomb."
+msgstr ""
+
+#: tomb:Create:forge_key:2074
+msgid "To make it faster you can move the mouse around."
+msgstr ""
+
+#: tomb:Create:forge_key:2075
+msgid "If you are on a server, you can use an Entropy Generation Daemon."
+msgstr ""
+
+#: tomb:Create:forge_key:2090
+msgid "Using GnuPG key(s) to encrypt your key: ::1 tomb key::"
+msgstr ""
+
+#: tomb:Create:forge_key:2092
+msgid "Choose the password of your key: ::1 tomb key::"
+msgstr ""
+
+#: tomb:Create:forge_key:2094
+msgid "(You can also change it later using 'tomb passwd'.)"
+msgstr ""
+
+#: tomb:Create:forge_key:2112
+msgid "The key does not seem to be valid."
+msgstr ""
+
+#: tomb:Create:forge_key:2113
+msgid "Dumping contents to screen:"
+msgstr ""
+
+#: tomb:Create:forge_key:2121
+msgid "Done forging ::1 key file::"
+msgstr ""
+
+#: tomb:Create:forge_key:2122
+msgid "Your key is ready:"
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2142
+msgid "No tomb specified for locking."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2143
+msgid "Usage: tomb lock file.tomb -k file.tomb.key"
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2150
+msgid "Commanded to lock tomb ::1 tomb file::"
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2153
+msgid "There is no tomb here. You have to dig it first."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2166
+msgid "Filesystem ::1 filesystem:: not supported on tombs smaller than 47MB."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2172
+msgid "Filesystem ::1 filesystem:: not supported on tombs smaller than 18MB."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2177
+msgid "Filesystem not supported: ::1 filesystem::"
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2181
+msgid "Selected filesystem type $filesystem."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2188
+msgid "Checking if the tomb is empty (we never step on somebody else's bones)."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2192
+msgid "The tomb was already locked with another key."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2193
+msgid "Operation aborted. I cannot lock an already locked tomb. Go dig a new one."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2195
+msgid "Fine, this tomb seems empty."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2203
+msgid "Locking using cipher: ::1 cipher::"
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2215
+msgid "Locking ::1 tomb file:: with ::2 tomb key file::"
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2217
+msgid "Formatting Luks mapped device."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2222
+msgid "cryptsetup luksFormat returned an error."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2227
+msgid "cryptsetup luksOpen returned an error."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2230
+msgid "Formatting your Tomb with $filesystem filesystem."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2249
+msgid "Tomb format returned an error."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2251
+msgid "Your tomb ::1 tomb file:: may be corrupted."
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2256
+msgid "Done locking ::1 tomb name:: using Luks dm-crypt ::2 cipher::"
+msgstr ""
+
+#: tomb:Create:lock_tomb_with_key:2257
+msgid "Your tomb is ready in ::1 tomb path:: and secured with key ::2 tomb key::"
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2267
+msgid "Commanded to reset key for tomb ::1 tomb path::"
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2270
+msgid "Command 'setkey' needs two arguments: the old key file and the tomb."
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2271
+msgid "I.e:	tomb -k new.tomb.key old.tomb.key secret.tomb"
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2272
+msgid "Execution aborted."
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2284
+msgid "Not a valid LUKS encrypted volume: ::1 volume::"
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2294
+msgid "Changing lock on tomb ::1 tomb name::"
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2295
+msgid "Old key: ::1 old key::"
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2306
+msgid "No valid password supplied for the old key."
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2312
+msgid "Unexpected error in luksOpen."
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2316
+msgid "New key: ::1 key file::"
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2326
+msgid "No valid password supplied for the new key."
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2335
+msgid "Unexpected error in luksChangeKey."
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2337
+msgid "Unexpected error in luksClose."
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2339
+msgid "Successfully changed key for tomb: ::1 tomb file::"
+msgstr ""
+
+#: tomb:Create:change_tomb_key:2340
+msgid "The new key is: ::1 new key::"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2370
+msgid "No tomb name specified for opening."
+msgstr ""
+
+#: tomb:Open:mount_tomb:2372
+msgid "Commanded to open tomb ::1 tomb name::"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2388
+msgid "Mountpoint not specified, using default: ::1 mount point::"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2391
+msgid "Opening ::1 tomb file:: on ::2 mount point::"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2398
+msgid "Mountpoint already in use: ::1 mount point::"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2405
+msgid "::1 tomb file:: is not a valid Luks encrypted storage file."
+msgstr ""
+
+#: tomb:Open:mount_tomb:2407
+msgid "This tomb is a valid LUKS encrypted device."
+msgstr ""
+
+#: tomb:Open:mount_tomb:2414
+msgid "Cipher is \"::1 cipher::\" mode \"::2 mode::\" hash \"::3 hash::\""
+msgstr ""
+
+#: tomb:Open:mount_tomb:2421
+msgid "Multiple key slots are enabled on this tomb. Beware: there can be a backdoor."
+msgstr ""
+
+#: tomb:Open:mount_tomb:2439
+msgid "Failure mounting the encrypted file."
+msgstr ""
+
+#: tomb:Open:mount_tomb:2449
+msgid "Success unlocking tomb ::1 tomb name::"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2453
+msgid "Filesystem detected: ::1 filesystem::"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2459
+msgid "Skipping filesystem checks in read-only"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2461
+msgid "Checking filesystem via ::1::"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2491
+msgid "Error mounting ::1 mapper:: on ::2 tombmount::"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2493
+msgid "Are mount options '::1 mount options::' valid?"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2498
+msgid "Cannot mount ::1 tomb name::"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2501
+msgid "Success opening ::1 tomb file:: on ::2 mount point::"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2515
+msgid "Last visit by ::1 user::(::2 tomb build::) from ::3 tty:: on ::4 host::"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2516
+msgid "on date ::1 date::"
+msgstr ""
+
+#: tomb:Open:mount_tomb:2517
+msgid "the door was slammed or shutdown called before umount."
+msgstr ""
+
+#: tomb:Open:exec_safe_bind_hooks:2579
+msgid "How pitiful!	A tomb, and no HOME."
+msgstr ""
+
+#: tomb:Open:exec_safe_bind_hooks:2583
+msgid "Cannot exec bind hooks without a mounted tomb."
+msgstr ""
+
+#: tomb:Open:exec_safe_bind_hooks:2599
+msgid "bind-hooks file is broken"
+msgstr ""
+
+#: tomb:Open:exec_safe_bind_hooks:2608
+msgid "bind-hooks map format: local/to/tomb local/to/$HOME"
+msgstr ""
+
+#: tomb:Open:exec_safe_bind_hooks:2612
+msgid "bind-hooks map format: local/to/tomb local/to/$HOME.	 Rolling back"
+msgstr ""
+
+#: tomb:Open:exec_safe_bind_hooks:2617
+msgid "bind-hook target not existent, skipping ::1 home::/::2 subdir::"
+msgstr ""
+
+#: tomb:Open:exec_safe_bind_hooks:2619
+msgid "bind-hook source not found in tomb, skipping ::1 mount point::/::2 subdir::"
+msgstr ""
+
+#: tomb:Open:exec_safe_func_hooks:2642
+msgid "Exec hook: ::1 exec hook:: ::2 action::"
+msgstr ""
+
+#: tomb:List:list_tombs:2668
+msgid "I can't see any ::1 status:: tomb, may they all rest in peace."
+msgstr ""
+
+#: tomb:List:list_tombs:2704
+msgid "::1 tombname:: open on ::2 tombmount:: using ::3 tombfsopts::"
+msgstr ""
+
+#: tomb:List:list_tombs:2709
+msgid "::1 tombname:: open since ::2 tombsince::"
+msgstr ""
+
+#: tomb:List:list_tombs:2712
+msgid "::1 tombname:: open by ::2 tombuser:: from ::3 tombtty:: on ::4 tombhost::"
+msgstr ""
+
+#: tomb:List:list_tombs:2716
+msgid "::1 tombname:: size ::2 tombtot:: of which ::3 tombused:: (::5 tombpercent::%) is used: ::4 tombavail:: free "
+msgstr ""
+
+#: tomb:List:list_tombs:2720
+msgid "::1 tombname:: warning: your tomb is almost full!"
+msgstr ""
+
+#: tomb:List:list_tombs:2726
+msgid "::1 tombname:: hooks ::2 hookdest::"
+msgstr ""
+
+#: tomb:List:list_tomb_binds:2787
+msgid "Internal error: list_tomb_binds called without argument."
+msgstr ""
+
+#: tomb:Index and search:index_tombs:2816
+msgid "Cannot index tombs on this system: updatedb (mlocate) not installed."
+msgstr ""
+
+#: tomb:Index and search:index_tombs:2820
+msgid "Cannot use GNU findutils for index/search commands."
+msgstr ""
+
+#: tomb:Index and search:index_tombs:2822
+msgid "Index command needs 'mlocate' to be installed."
+msgstr ""
+
+#: tomb:Index and search:index_tombs:2830
+msgid "There seems to be no open tomb engraved as [::1::]"
+msgstr ""
+
+#: tomb:Index and search:index_tombs:2832
+msgid "I can't see any open tomb, may they all rest in peace."
+msgstr ""
+
+#: tomb:Index and search:index_tombs:2834
+msgid "Creating and updating search indexes."
+msgstr ""
+
+#: tomb:Index and search:index_tombs:2847
+msgid "Skipping ::1 tomb name:: (.noindex found)."
+msgstr ""
+
+#: tomb:Index and search:index_tombs:2849
+msgid "Indexing ::1 tomb name:: filenames..."
+msgstr ""
+
+#: tomb:Index and search:index_tombs:2854
+msgid "Indexing ::1 tomb name:: contents..."
+msgstr ""
+
+#: tomb:Index and search:index_tombs:2856
+msgid "Generating a new swish-e configuration file: ::1 swish conf::"
+msgstr ""
+
+#: tomb:Index and search:index_tombs:2926
+msgid "Search index updated."
+msgstr ""
+
+#: tomb:Index and search:search_tombs:2948
+msgid "Searching for: ::1::"
+msgstr ""
+
+#: tomb:Index and search:search_tombs:2956
+msgid "Searching filenames in tomb ::1 tomb name::"
+msgstr ""
+
+#: tomb:Index and search:search_tombs:2958
+msgid "Matches found: ::1 matches::"
+msgstr ""
+
+#: tomb:Index and search:search_tombs:2963
+msgid "Searching contents in tomb ::1 tomb name::"
+msgstr ""
+
+#: tomb:Index and search:search_tombs:2966
+msgid "Skipping tomb ::1 tomb name::: not indexed."
+msgstr ""
+
+#: tomb:Index and search:search_tombs:2967
+msgid "Run 'tomb index' to create indexes."
+msgstr ""
+
+#: tomb:Index and search:search_tombs:2969
+msgid "Search completed."
+msgstr ""
+
+#: tomb:Resize:resize_tomb:2981
+msgid "Commanded to resize tomb ::1 tomb name:: to ::2 size:: mebibytes."
+msgstr ""
+
+#: tomb:Resize:resize_tomb:2983
+msgid "No tomb name specified for resizing."
+msgstr ""
+
+#: tomb:Resize:resize_tomb:2984
+msgid "Cannot find ::1::"
+msgstr ""
+
+#: tomb:Resize:resize_tomb:2988
+msgid "Aborting operations: new size was not specified, use -s"
+msgstr ""
+
+#: tomb:Resize:resize_tomb:3007
+msgid "You must specify the new size of ::1 tomb name::"
+msgstr ""
+
+#: tomb:Resize:resize_tomb:3009
+msgid "Size is not an integer."
+msgstr ""
+
+#: tomb:Resize:resize_tomb:3021
+msgid "Error creating the extra resize ::1 size::, operation aborted."
+msgstr ""
+
+#: tomb:Resize:resize_tomb:3028
+msgid "Tomb seems resized already, operating filesystem stretch"
+msgstr ""
+
+#: tomb:Resize:resize_tomb:3030
+msgid "The new size must be greater then old tomb size."
+msgstr ""
+
+#: tomb:Resize:resize_tomb:3035
+msgid "opening tomb"
+msgstr ""
+
+#: tomb:Resize:resize_tomb:3040
+msgid "cryptsetup failed to resize ::1 mapper::"
+msgstr ""
+
+#: tomb:Resize:resize_tomb:3049
+msgid "e2fsck failed to check ::1 mapper::"
+msgstr ""
+
+#: tomb:Resize:resize_tomb:3052
+msgid "resize2fs failed to resize ::1 mapper::"
+msgstr ""
+
+#: tomb:Resize:resize_tomb:3057
+msgid "filesystem check failed on ::1 mapper::"
+msgstr ""
+
+#: tomb:Resize:resize_tomb:3066
+msgid "filesystem resize failed on ::1 mapper::"
+msgstr ""
+
+#: tomb:Close:umount_tomb:3095
+msgid "There is no open tomb to be closed."
+msgstr ""
+
+#: tomb:Close:umount_tomb:3098
+msgid "Too many tombs mounted, please specify one (see tomb list)"
+msgstr ""
+
+#: tomb:Close:umount_tomb:3099
+msgid "or issue the command 'tomb close all' to close them all."
+msgstr ""
+
+#: tomb:Close:umount_tomb:3118
+msgid "Tomb not found: ::1 tomb file::"
+msgstr ""
+
+#: tomb:Close:umount_tomb:3119
+msgid "Please specify an existing tomb."
+msgstr ""
+
+#: tomb:Close:umount_tomb:3127
+msgid "close exec-hook returns a non-zero error code: ::1 error::"
+msgstr ""
+
+#: tomb:Close:umount_tomb:3128
+msgid "Operation aborted"
+msgstr ""
+
+#: tomb:Close:umount_tomb:3132
+msgid "Closing tomb ::1 tomb name:: mounted on ::2 mount point::"
+msgstr ""
+
+#: tomb:Close:umount_tomb:3140
+msgid "Closing tomb bind hook: ::1 hook::"
+msgstr ""
+
+#: tomb:Close:umount_tomb:3142
+msgid "Tomb bind hook ::1 hook:: is busy, cannot close tomb."
+msgstr ""
+
+#: tomb:Close:umount_tomb:3162
+msgid "Tomb is busy, cannot umount!"
+msgstr ""
+
+#: tomb:Close:umount_tomb:3175
+msgid "Error occurred in cryptsetup luksClose ::1 mapper::"
+msgstr ""
+
+#: tomb:Close:umount_tomb:3183
+msgid "Tomb ::1 tomb name:: closed: your bones will rest in peace."
+msgstr ""
+
+#: tomb:Close:list_processes:3199
+msgid "Listing processes running inside all open tombs..."
+msgstr ""
+
+#: tomb:Close:list_processes:3201
+msgid "Listing processes running inside tomb '::1 tombname::'..."
+msgstr ""
+
+#: tomb:Close:list_processes:3215
+msgid "::1 tombname:: ::2 cmd:: (::3 owner::)"
+msgstr ""
+
+#: tomb:Close:list_processes:3220
+msgid "::1 foundproc:: running processes found inside ::2 numtombs:: open tombs"
+msgstr ""
+
+#: tomb:Close:slam_tomb:3249
+msgid "Slamming tomb ::1 tombname:: mounted on ::2 tombmount::"
+msgstr ""
+
+#: tomb:Close:slam_tomb:3259
+msgid "::1 tombname:: sending ::2 sig:: to ::3 cmd:: (::4 uid::)"
+msgstr ""
+
+#: tomb:Close:slam_tomb:3269
+msgid "Can't kill ::1 process:: ::2 pcmd:: (::3 powner::)"
+msgstr ""
+
+#: tomb:Main routine:main:3369
+msgid "Error parsing."
+msgstr ""
+
+#: tomb:Main routine:main:3379
+msgid "There's no such command \"::1 subcommand::\"."
+msgstr ""
+
+#: tomb:Main routine:main:3380
+msgid "Please try -h for help."
+msgstr ""
+
+#: tomb:Main routine:main:3392
+msgid "Some error occurred during option processing."
+msgstr ""
+
+#: tomb:Main routine:main:3393
+msgid "See \"tomb help\" for more info."
+msgstr ""
+
+#: tomb:Main routine:main:3405
+msgid "Unrecognized option ::1 arg:: for subcommand ::2 subcommand::"
+msgstr ""
+
+#: tomb:Main routine:main:3421
+msgid "You specified option ::1 option::, which is DANGEROUS and should only be used for testing\nIf you really want so, add --unsafe"
+msgstr ""
+
+#: tomb:Main routine:main:3429
+msgid "Privilege escalation tool configured: ::1 exec::"
+msgstr ""
+
+#: tomb:Main routine:main:3459
+msgid "The create command is deprecated, please use dig, forge and lock instead."
+msgstr ""
+
+#: tomb:Main routine:main:3460
+msgid "For more informations see Tomb's manual page (man tomb)."
+msgstr ""
+
+#: tomb:Main routine:main:3501
+msgid "lsof not installed: cannot slam tombs."
+msgstr ""
+
+#: tomb:Main routine:main:3502
+msgid "Trying a regular close."
+msgstr ""
+
+#: tomb:Main routine:main:3509
+msgid "Resize2fs not installed: cannot resize tombs."
+msgstr ""
+
+#: tomb:Main routine:main:3535
+msgid "QREncode not installed: cannot engrave keys on paper."
+msgstr ""
+
+#: tomb:Main routine:main:3552
+msgid "Steghide not installed: cannot bury keys into images."
+msgstr ""
+
+#: tomb:Main routine:main:3559
+msgid "Steghide not installed: cannot exhume keys from images."
+msgstr ""
+
+#: tomb:Main routine:main:3566
+msgid "Cloakify not installed: cannot cipher keys into texts"
+msgstr ""
+
+#: tomb:Main routine:main:3573
+msgid "Decloakify not installed: cannot decipher keys from texts"
+msgstr ""
+
+#: tomb:Main routine:main:3588
+msgid "Tomb ::1 version:: - a strong and gentle undertaker for your secrets"
+msgstr ""
+
+#: tomb:Main routine:main:3590
+msgid " Copyright (C) 2007-2021 Dyne.org Foundation, License GNU GPL v3+"
+msgstr ""
+
+#: tomb:Main routine:main:3591
+msgid " This is free software: you are free to change and redistribute it"
+msgstr ""
+
+#: tomb:Main routine:main:3592
+msgid " For the latest sourcecode go to <http://dyne.org/software/tomb>"
+msgstr ""
+
+#: tomb:Main routine:main:3597
+msgid " This source code is distributed in the hope that it will be useful,"
+msgstr ""
+
+#: tomb:Main routine:main:3598
+msgid " but WITHOUT ANY WARRANTY; without even the implied warranty of"
+msgstr ""
+
+#: tomb:Main routine:main:3599
+msgid " MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+msgstr ""
+
+#: tomb:Main routine:main:3601
+msgid " When in need please refer to <http://dyne.org/support>."
+msgstr ""
+
+#: tomb:Main routine:main:3603
+msgid "System utils:"
+msgstr ""
+
+#: tomb:Main routine:main:3615
+msgid "Optional utils:"
+msgstr ""
+
+#: tomb:Main routine:main:3625
+msgid "Command \"::1 subcommand::\" not recognized."
+msgstr ""
+
+#: tomb:Main routine:main:3626
+msgid "Try -h for help."
+msgstr ""
+


### PR DESCRIPTION
Where to start from?

### 1) Translations: updated 'es', 'fr', 'it' and 'ru.po' to line up help message (PR #481 and [Jaromil request in PR #483](https://github.com/dyne/Tomb/pull/483#issuecomment-1608820052)).

> One request before merging, which should be easy to do: can you please also update the .po translations with this detail? so we keep them aligned.

Done. I used a script to print help output out of PO files and check all them:
```sh
#!/usr/bin/env zsh
clear
egrep -A 141 'Syntax:' $1 | 
egrep -v "^(#|msgid|\s*$)" | 
sed 's/msgstr \"//g' | 
sed 's/\" / /g' | 
grep -v "^\"" |
sed 's/\"$//g'
```
Not important, just saying.

### 2) Updated Brazilian Portuguese translation (pt_BR). Also updated Makefile to include this translation.
Related to issue #482. I have translated to `pt_BR` before Weblate was created, sorry. But thank you for that.

### 3) Added Brazilian Portuguese (pt_BR) translation (for Tomb 2.10). Also created tomb.pot template for version 2.10.
Hard to explain, better to read the ne created README for extras/translations folder. It's all very well explained there.

### 4) Created a README file in extras/translations to clear up confused issues about translations versions.
This is a huge point, ALL translations in `extras/translations` are based upon `Tomb 2.3`, _not_ the `current 2.10` or the `stable 2.9`. I think i have explained it very well in README. Please read it.