### PR TITLE
Fix operators to compare numerically, not lexicographically

### DIFF
--- a/tomb
+++ b/tomb
@@ -2162,13 +2162,13 @@ lock_tomb_with_key() {
 			ext3|ext4) ;;
 			ext3maxinodes|ext4maxinodes) ;;
 			btrfs)
-				if [[ $tombsize < 49283072 ]]; then
+				if [[ $tombsize -lt 49283072 ]]; then
 					_failure "Filesystem ::1 filesystem:: not supported on tombs smaller than 47MB." \
 						$filesystem
 				fi
 				;;
 			btrfsmixedmode)
-				if [[ $tombsize < 18874368 ]]; then
+				if [[ $tombsize -lt 18874368 ]]; then
 					_failure "Filesystem ::1 filesystem:: not supported on tombs smaller than 18MB." \
 						$filesystem
 				fi


### PR DESCRIPTION
The operator < compares two strings lexicographically resulting in that a 100MB tomb is considered smaller than 47MB or 18MB.

Closes #489

__________
Took the liberty and created the PR which incorporates the fix for #489