### PR TITLE
Fix spaces in bind-hooks paths

### DIFF
--- a/tomb
+++ b/tomb
@@ -2594,8 +2594,11 @@ exec_safe_bind_hooks() {
 	# each line, using zsh word separator array subscript
 	_bindhooks="${mapfile[${mnt}/bind-hooks]}"
 	for h in ${(f)_bindhooks}; do
+		h=${h//\\ /__ESC_SPACE__}
 		s="${h[(w)1]}"
 		d="${h[(w)2]}"
+		s=${s//__ESC_SPACE__/ }
+		d=${d//__ESC_SPACE__/ }
 		[[ -z $s ]] && { _warning "bind-hooks file is broken"; return 1 }
 		[[ -z $d ]] && { _warning "bind-hooks file is broken"; return 1 }
 		maps+=($s $d)


### PR DESCRIPTION
https://github.com/dyne/Tomb/blob/a0b633fb774626e6f6e9767b70247bf5490dd0e2/tomb#L2593-L2604

The option to target folders/files that have spaces in the name would be ideal, so I added a little work around.