### PR TITLE
Use cat instead of _cat

### DIFF
--- a/tomb
+++ b/tomb
@@ -2525,7 +2525,7 @@ mount_tomb() {
 		if command -v hostname >/dev/null; then
 			_update_control_file "${tombmount}/.host" `hostname`
 		elif [[ -r /etc/hostname ]]; then
-			_update_control_file "${tombmount}/.host" $(_cat /etc/hostname)
+			_update_control_file "${tombmount}/.host" $(cat /etc/hostname)
 		else
 			_update_control_file "${tombmount}/.host" localhost
 		fi


### PR DESCRIPTION
_cat is not defined/autoloaded anywhere, so use plain unix cat utility to avoid getting "command not found" error