### PR TITLE
list_processes: use lsof to list processes

### DIFF
--- a/tomb
+++ b/tomb
@@ -3189,10 +3189,8 @@ umount_tomb() {
 
 list_processes() {
 	# $1 = (optional) name of tomb
-	# returns a list of process UIDs, one per line
+	# runs lsof on the mounted_tombs
 	local mounted_tombs i
-	local pnum puid pcmd powner found
-	found=0
 	mounted_tombs=(`list_tomb_mounts $1`)
 	if [[ "${#mounted_tombs}" -gt 0 ]]; then
 		if [[ -z $1 ]]; then
@@ -3204,21 +3202,9 @@ list_processes() {
 		for i in ${mounted_tombs}; do
 			_verbose "scanning tomb: ::1 tombmount::" $i
 			tombmount="${i[(ws:;:)2]}"
-			tombname=${i[(ws:;:)5]}
-			for pnum in ${(f)"$(_sudo lsof -t +D "$tombmount")"}; do
-				found=$(($found + 1))
-				_verbose "process found: $pnum"
-				puid=$(cat /proc/${pnum}/loginuid)
-				pcmd=$(cat /proc/${pnum}/cmdline)
-				powner=`_get_username $puid`
-				_verbose "process found: $pnum $pcmd ($powner)"
-				_message "::1 tombname:: ::2 cmd:: (::3 owner::)" \
-						 $tombname $pcmd $powner
-			done
+			_sudo lsof +D "${i[(ws:;:)2]}"
 		done
 	fi
-	_message "::1 foundproc:: running processes found inside ::2 numtombs:: open tombs" \
-			 $found ${#mounted_tombs}
 	return 0
 }
 


### PR DESCRIPTION
Parsing the output from lsof had possibilities for race conditions. Either due to short lived processes or issuing "tomb ps" from a terminal which cwd is from inside the tomb. This would for example list available users on the system. To avoid this use the lsof output directly.

In the future formatting could be reintroduced via commands like "lsof +D "$tombmount" -F Lc" or "lsof +D "$tombmount" -F Lc0".

This fixes #503
___________
The lazy solution for #503. For me the output is enough :D

Example:
```
$  ./tomb ps
tomb (*) Listing processes running inside all open tombs...
COMMAND  PID   USER  FD   TYPE DEVICE SIZE/OFF NODE NAME
zsh     1221 omnius cwd    DIR  254,0    12288    2 /run/media/omnius/Z
```

This doesn't touch `slam_tomb()` which in general uses the same logic and should probably be updated.