### PR TITLE
manpage: typo fix, column formatting, .EX/.EE macros indentation etc

### DIFF
--- a/doc/tomb.1
+++ b/doc/tomb.1
@@ -375,7 +375,7 @@ base root of the tomb.
 .IP "bind-hooks"
 This hook file consists of a simple text file named \fIbind-hooks\fR
 containing a two column list of paths to files or directories inside
-the tomb. The files and directories will be be made directly
+the tomb. The files and directories will be made directly
 accessible by the tomb \fIopen\fR command inside the current user's
 home directory. Tomb uses internally the "mount \-o bind" command to
 bind locations inside the tomb to locations found in $HOME. In the

--- a/doc/tomb.1
+++ b/doc/tomb.1
@@ -383,10 +383,10 @@ first column are indicated paths relative to the tomb and in the
 second column are indicated paths relative to $HOME contents, for
 example:
 .EX
-  mail          mail
-  .gnupg        .gnupg
-  .fmrc         .fetchmailrc
-  .mozilla      .mozilla
+	mail          mail
+	.gnupg        .gnupg
+	.fmrc         .fetchmailrc
+	.mozilla      .mozilla
 .EE
 
 .B
@@ -417,8 +417,8 @@ whole system's security: just add such a line to \fI/etc/sudoers\fR:
 To avoid that tomb execution is logged by \fIsyslog\fR also add:
 
 .EX
-Cmnd_Alias TOMB = /usr/local/bin/tomb
-Defaults!TOMB !syslog
+	Cmnd_Alias TOMB = /usr/local/bin/tomb
+	Defaults!TOMB !syslog
 .EE
 
 .SH PASSWORD INPUT
@@ -469,8 +469,8 @@ prefix all invocations of tomb with a blank space, including two lines
 in ".zshrc":
 
 .EX
-export HISTIGNORESPACE=1
-alias tomb=' tomb'
+	export HISTIGNORESPACE=1
+	alias tomb=' tomb'
 .EE
 
 .SH PASSWORD INPUT
@@ -483,7 +483,7 @@ the X session initialization ("~/.xsession" or "~/.xinitrc" files) with this
 command:
 
 .EX
-eval $(gpg-agent --daemon --write-env-file "${HOME}/.gpg-agent-info")
+	eval $(gpg-agent --daemon --write-env-file "${HOME}/.gpg-agent-info")
 .EE
 
 In the future it may become mandatory to run gpg-agent when using tomb.
@@ -570,11 +570,11 @@ keeping all its profile data inside it:
 	cat <<EOF > /media/FOX.tomb/exec-hooks
 #!/bin/sh
 if [ "$1" = "open" ]; then
-  firefox -no-remote -profile "$2"/firefox-pro &
+	firefox -no-remote -profile "$2"/firefox-pro &
 fi
 EOF
-	chmod +x     /media/FOX.tomb/exec-hooks
-        mkdir /media/FOX.tomb/firefox-pro
+	chmod +x /media/FOX.tomb/exec-hooks
+	mkdir /media/FOX.tomb/firefox-pro
 .EE
 
 .IP \(bu
@@ -585,13 +585,13 @@ Script a tomb to archive Pictures using Shotwell, launching it on open:
 	cat <<EOF > /media/Pictures.tomb/bind-hooks
 Pictures Pictures
 EOF
-        cat <<EOF > /media/Pictures.tomb/exec-hooks
+	cat <<EOF > /media/Pictures.tomb/exec-hooks
 #!/bin/sh
 if [ "$1" = "open" ]; then
-  which shotwell > /dev/null
-  if [ "$?" = "0" ]; then
-    shotwell -d "$2"/Pictures/.shotwell &
-  fi
+	which shotwell > /dev/null
+	if [ "$?" = "0" ]; then
+		shotwell -d "$2"/Pictures/.shotwell &
+	fi
 fi
 EOF
 	chmod +x /media/Pictures.tomb/exec-hooks

--- a/doc/tomb.1
+++ b/doc/tomb.1
@@ -69,7 +69,7 @@ Linux documentation. The \fI--filesystem\fR option can be used to
 specify an alternative filesystem used to format the tomb,
 in place of the default "ext4". This operation requires root
 privileges to loopback mount, format the tomb (using LUKS and mkfs),
-then set the key in its first LUKS slot. 
+then set the key in its first LUKS slot.
 
 .RS
 Supported filesystems for \fI--filesystem\fR:
@@ -122,7 +122,7 @@ internally to enumerate processes running in one or all tombs.
 .IP "index"
 Creates or updates the search indexes of all tombs currently open:
 enables use of the \fIsearch\fR command using simple word patterns on
-file names. Indexes are created using mlocate's updatedb(8) and
+file names. Indexes are created using mlocate/plocate's updatedb(8) and
 swish-e(1) if they are found on the system. Indexes allow one to search
 very fast for filenames and contents inside a tomb, they are stored
 inside it and are not accessible if the Tomb is closed. To avoid
@@ -132,7 +132,7 @@ indexing a specific tomb simply touch a \fI.noindex\fR file in it.
 .IP "search"
 Takes any string as argument and searches for them through all tombs
 currently open and previously indexed using the \fIindex\fR command.
-The search matches filenames if mlocate is installed and then also
+The search matches filenames if mlocate/plocate is installed and then also
 file contents if swish++ is present on the system, results are listed
 on the console.
 
@@ -505,7 +505,7 @@ commands: \fIopen\fR, \fIforge\fR \fIsetkey\fR, \fIpasswd\fR,
 Using the package libsphinx
 .UR https://github.com/stef/libsphinx
 .UE
-and its python client/daemon implementation pwdsphinx 
+and its python client/daemon implementation pwdsphinx
 .UR https://github.com/stef/pwdsphinx
 .UE
 is possible to store and retrieve safely the password that locks the

--- a/doc/tomb.1
+++ b/doc/tomb.1
@@ -475,7 +475,12 @@ alias tomb=' tomb'
 
 .SH PASSWORD INPUT
 
-Tomb uses the external program "pinentry" to let users type the key password into a terminal or a graphical window. This program works in conjunction with "gpg-agent", a daemon running in background to facilitate secret key management with gpg. It is recommended one runs "gpg-agent" launching it from the X session initialization ("~/.xsession" or "~/.xinitrc" files) with this command:
+Tomb uses the external program "pinentry" to let users type the key password
+into a terminal or a graphical window. This program works in conjunction with
+"gpg-agent", a daemon running in background to facilitate secret key
+management with gpg. It is recommended one runs "gpg-agent" launching it from
+the X session initialization ("~/.xsession" or "~/.xinitrc" files) with this
+command:
 
 .EX
 eval $(gpg-agent --daemon --write-env-file "${HOME}/.gpg-agent-info")


### PR DESCRIPTION
Under `bind-hooks`, in the line:
```
the tomb. The files and directories will be be made directly
```
Word `be` appears twice.

And in PASSWORD INPUT, added linke breaks to fit 80 columns. It was a "very long line". Just keeping the document standard.

Better formatting of .EX/.EE macros adding indentation.

Replaced `mlocate` with `mlocate/plocate`. Since commit 59d7331 added plocate as a possibility.