### PR TITLE
add run0 support as sudo replacement

### DIFF
--- a/doc/tomb.1
+++ b/doc/tomb.1
@@ -303,7 +303,7 @@ Default is 18 which is 250 MiB (2^18 = 262,144 kilobytes).
 .B
 .IP "--sudo \fI<executable>\fR"
 Select a different tool than sudo for privilege escalation.
-Alternatives supported so far are: pkexec, doas, sup, sud. For any
+Alternatives supported so far are: pkexec, doas, sup, sud, run0. For any
 alternative to work the executable must be included in the current
 PATH.
 .B

--- a/tomb
+++ b/tomb
@@ -114,7 +114,7 @@ _sudo() {
 	if option_is_set --sudo; then
                pescmd=`option_value --sudo`
 		case `basename $pescmd` in
-			"doas"|"sup"|"sud"|"pkexec")
+			"doas"|"sup"|"sud"|"pkexec"|"run0")
 				command -v $pescmd > /dev/null || _failure "$pescmd executable not found"
 				_verbose "Super user execution using $pescmd"
 				${pescmd} ${@}


### PR DESCRIPTION
run0 is a new sudo replacement built into systemd, see https://www.freedesktop.org/software/systemd/man/devel/run0.html.

I tested this with tomb and it looks like it works without any additional changes, so it should be fine to just add it to the allowlist.