### PR TITLE
Avoid manual handling of loop devices

### DIFF
--- a/extras/test/75_hooks.sh
+++ b/extras/test/75_hooks.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env zsh
 
-export test_description="Testing tomb bind hooks"
+export test_description="Testing tomb bind hooks & mounts"
 
 TEMPHOME=$HOME
 
@@ -18,13 +18,23 @@ test_expect_success 'Testing bind hooks' '
     tt_close &&
     touch "$TEMPHOME/$bindtest" &&
     tt_open --tomb-pwd $DUMMYPASS &&
-	echo "$RND" &&
-	cat "$TEMPHOME/$bindtest" &&
+    echo "$RND" &&
+    cat "$TEMPHOME/$bindtest" &&
     tt list $testname &&
     tt_close
     '
 
     # RND2=$(cat "$TEMPHOME/$bindtest") &&
     # [[ "$RND" = "$RND2" ]] &&
+
+test_expect_success 'Testing outside bind mounts' '
+    tt_open --tomb-pwd $DUMMYPASS &&
+    tt_set_ownership "$MEDIA/$testname" &&
+    sudo mkdir "$MEDIA/$testname-bind" &&
+    sudo mount --bind "$MEDIA/$testname" "$MEDIA/$testname-bind" &&
+    tt list $testname &&
+    tt_close &&
+    sudo rmdir "$MEDIA/$testname-bind"
+    '
 
 test_done

--- a/tomb
+++ b/tomb
@@ -3079,9 +3079,9 @@ umount_tomb() {
 		_message "Closing tomb ::1 tomb name:: mounted on ::2 mount point::" \
 				 $tombname "$tombmount"
 
-		# check if there are binded dirs and close them
+		# check if there are bind mounted dirs and close them
 		bind_tombs=(`list_tomb_binds $tombname "$tombmount"`)
-		for b in ${(f)"$(list_tomb_binds $tombname "$tombmount")"}; do
+		for b in ${bind_tombs}; do
 			bind_mapper="${b[(ws:;:)1]}"
 			bind_mount="${b[(ws:;:)2]}"
 			_message "Closing tomb bind hook: ::1 hook::" "$bind_mount"

--- a/tomb
+++ b/tomb
@@ -187,12 +187,10 @@ _endgame() {
 	done
 	unset TOMBTMPFILES
 
-	# Detach loop devices
-	for l in $TOMBLOOPDEVS; do
-		_sudo losetup -d "$l"
-	done
+	# Clear information regarding loop devices
+	# No need for an explicit detach as cryptsetup
+	# sets the AUTOCLEAR flag
 	unset TOMBLOOPDEVS
-
 }
 
 # Trap functions for the _endgame event
@@ -707,7 +705,7 @@ is_valid_tomb() {
 
 	# checks if Tomb already mounted (or we cannot alter it)
 	local maphash=`realpath $TOMBPATH | sha256sum`
-	lo_mount # fills TOMBLOOP with next loop
+	lo_check # fills TOMBLOOP with next loop if available
 	TOMBMAPPER="tomb.$TOMBNAME.${maphash[(w)1]}.`basename $TOMBLOOP`"
 	local mounted_tombs=(`list_tomb_mounts`)
 	local usedmapper
@@ -724,9 +722,8 @@ is_valid_tomb() {
 	return 0
 }
 
-
-# $1 is the tomb file to be lomounted
-lo_mount() {
+# $1 is the tomb file which needs a loop device
+lo_check() {
 	tpath="$1"
 
 	# check if we have support for loop mounting
@@ -740,23 +737,9 @@ lo_mount() {
 
 	[[ "$tpath" == "" ]] && return 0
 
-
-	# allocates the next loopback for our file
-	_sudo losetup -f "$tpath" || _failure "Loopback mount failed: ::1 path:: on ::2 loop::" "$tpath" $TOMBLOOP
-
 	TOMBLOOPDEVS+=("$TOMBLOOP") # add to array of lodevs used
 
 	return 0
-}
-
-# print out latest loopback mounted
-lo_new() { print - "${TOMBLOOPDEVS[${#TOMBLOOPDEVS}]}" }
-
-# $1 is the path to the lodev to be preserved after quit
-lo_preserve() {
-	_verbose "lo_preserve on ::1 path::" $1
-	# remove the lodev from the tomb_lodevs array
-	TOMBLOOPDEVS=("${(@)TOMBLOOPDEVS:#$1}")
 }
 
 # eventually used for debugging
@@ -2212,12 +2195,10 @@ lock_tomb_with_key() {
 		_success "Selected filesystem type $filesystem."
 	}
 
-	lo_mount "$TOMBPATH"
-
-	_verbose "Loop mounted on ::1 mount point::" $TOMBLOOP
+	lo_check "$TOMBPATH"
 
 	_message "Checking if the tomb is empty (we never step on somebody else's bones)."
-	_sudo cryptsetup isLuks ${TOMBLOOP}
+	_sudo cryptsetup isLuks ${TOMBPATH}
 	if [ $? = 0 ]; then
 		# is it a LUKS encrypted nest? then bail out and avoid reformatting it
 		_warning "The tomb was already locked with another key."
@@ -2248,12 +2229,12 @@ lock_tomb_with_key() {
 	_message "Formatting Luks mapped device."
 	_cryptsetup --batch-mode \
 				--cipher ${cipher} --hash sha512 --key-size 512 --key-slot 0 \
-				luksFormat ${TOMBLOOP}
+				luksFormat ${TOMBPATH}
 	[[ $? == 0 ]] || {
 		_warning "cryptsetup luksFormat returned an error."
 		_failure "Operation aborted." }
 
-	_cryptsetup --cipher ${cipher} --hash sha512 luksOpen ${TOMBLOOP} tomb.tmp
+	_cryptsetup --cipher ${cipher} --hash sha512 luksOpen ${TOMBPATH} tomb.tmp
 	[[ $? == 0 ]] || {
 		_warning "cryptsetup luksOpen returned an error."
 		_failure "Operation aborted." }
@@ -2306,10 +2287,8 @@ change_tomb_key() {
 	_check_swap
 
 	is_valid_tomb $tombpath
-
-	lo_mount "$TOMBPATH"
-
-	_sudo cryptsetup isLuks ${TOMBLOOP}
+	lo_check "$TOMBPATH"
+	_sudo cryptsetup isLuks ${TOMBPATH}
 	# is it a LUKS encrypted nest? we check one more time
 	[[ $? == 0 ]] || {
 		_failure "Not a valid LUKS encrypted volume: ::1 volume::" $TOMBPATH }
@@ -2339,7 +2318,7 @@ change_tomb_key() {
 
 	# luksOpen the tomb (not really mounting, just on the loopback)
 	print -R -n - "$old_secret" | _sudo cryptsetup --key-file - \
-										luksOpen ${TOMBLOOP} ${TOMBMAPPER}
+										luksOpen ${TOMBPATH} ${TOMBMAPPER}
 	[[ $? == 0 ]] || _failure "Unexpected error in luksOpen."
 
 	_load_key # Try loading new key from option -k and set TOMBKEYFILE
@@ -2361,7 +2340,7 @@ change_tomb_key() {
 	print -R -n - "$TOMBSECRET" >> $tmpnewkey
 
 	print -R -n - "$old_secret" | _sudo cryptsetup --key-file - \
-										luksChangeKey "$TOMBLOOP" "$tmpnewkey"
+										luksChangeKey "$TOMBPATH" "$tmpnewkey"
 
 	[[ $? == 0 ]] || _failure "Unexpected error in luksChangeKey."
 
@@ -2429,15 +2408,15 @@ mount_tomb() {
 			_failure "Mountpoint already in use: ::1 mount point::" "$tombmount"
 	done
 
-	lo_mount "$TOMBPATH"
 
-	_sudo cryptsetup isLuks ${TOMBLOOP} || {
+	lo_check "$TOMBPATH"
+	_sudo cryptsetup isLuks ${TOMBPATH} || {
 		# is it a LUKS encrypted nest? see cryptsetup(1)
 		_failure "::1 tomb file:: is not a valid Luks encrypted storage file." $TOMBFILE }
 
 	_message "This tomb is a valid LUKS encrypted device."
 
-	luksdump="`_sudo cryptsetup luksDump ${TOMBLOOP}`"
+	luksdump="`_sudo cryptsetup luksDump ${TOMBPATH}`"
 	tombdump=(`print $luksdump | awk '
 		/^Cipher name/ {print $3}
 		/^Cipher mode/ {print $3}
@@ -2465,12 +2444,9 @@ mount_tomb() {
 	}
 	[[ $? == 0 ]] || _failure "No valid password supplied."
 
-	_cryptsetup luksOpen ${TOMBLOOP} ${TOMBMAPPER}
+	_cryptsetup luksOpen ${TOMBPATH} ${TOMBMAPPER}
 	[[ $? = 0 ]] || {
 		_failure "Failure mounting the encrypted file." }
-
-	# preserve the loopdev after exit
-	lo_preserve "$TOMBLOOP"
 
 	# array: [ cipher, keysize, loopdevice ]
 	tombstat=(`_sudo cryptsetup status ${TOMBMAPPER} | awk '
@@ -2482,7 +2458,7 @@ mount_tomb() {
 
 	filesystem=`_detect_filesystem /dev/mapper/${TOMBMAPPER}`
 	_message "Filesystem detected: ::1 filesystem::" $filesystem
-	# TODO: check if FS is supported, else close luks and loop
+	# TODO: check if FS is supported, else close luks
 
 	_verbose "Tomb engraved as ::1 tomb name::" $TOMBNAME
 
@@ -2525,7 +2501,6 @@ mount_tomb() {
 		# TODO: move cleanup to _endgame()
 		[[ -d "$tombmount" ]] && _sudo rmdir "$tombmount"
 		[[ -e /dev/mapper/$TOMBMAPPER ]] && _sudo cryptsetup luksClose $TOMBMAPPER
-		# The loop is taken care of in _endgame()
 		_failure "Cannot mount ::1 tomb name::" $TOMBNAME
 	}
 
@@ -2738,7 +2713,7 @@ awk "/mapper/"' { print $2 ";" $3 ";" $4 ";" $5 }'`
 		_message "::1 tombname:: open on ::2 tombmount:: using ::3 tombfsopts::" \
 				 $tombname "$tombmount" $tombfsopts
 
-		_verbose "::1 tombname:: /dev/::2 tombloop:: device mounted (detach with losetup -d)" $tombname $tombloop
+		_verbose "::1 tombname:: attached to /dev/::2 tombloop:: device" $tombname $tombloop
 
 		_message "::1 tombname:: open since ::2 tombsince::" $tombname $tombsince
 
@@ -3002,10 +2977,10 @@ resize_tomb() {
 		_failure "The new size must be greater then old tomb size."
 	fi
 
-	lo_mount "$TOMBPATH"
+	lo_check "$TOMBPATH"
 
 	_message "opening tomb"
-	_cryptsetup luksOpen ${TOMBLOOP} ${TOMBMAPPER} || {
+	_cryptsetup luksOpen ${TOMBPATH} ${TOMBMAPPER} || {
 		_failure "Failure mounting the encrypted file." }
 
 	_sudo cryptsetup resize "${TOMBMAPPER}" || {
@@ -3145,12 +3120,6 @@ umount_tomb() {
 
 		_sudo cryptsetup luksClose $mapper ||
 			_failure "Error occurred in cryptsetup luksClose ::1 mapper::" $mapper
-
-		# Normally the loopback device is detached when unused
-		[[ -e "/dev/$tombloop" ]] && {
-			_sudo losetup -d "/dev/$tombloop" ||
-				_verbose "/dev/$tombloop was already closed."
-		}
 
 		_success "Tomb ::1 tomb name:: closed: your bones will rest in peace." $tombname
 

--- a/tomb
+++ b/tomb
@@ -2730,7 +2730,7 @@ awk "/mapper/"' { print $2 ";" $3 ";" $4 ";" $5 }'`
 		}
 
 		# Now check hooks
-		mounted_hooks=(`list_tomb_binds $tombname "$tombmount"`)
+		mounted_hooks=(`list_tomb_binds "$mapper"`)
 		for h in ${mounted_hooks}; do
 			_message "::1 tombname:: hooks ::2 hookdest::" \
 					 $tombname ${h[(ws:;:)2]}
@@ -2776,23 +2776,16 @@ BEGIN { main="" }
 # needs two arguments: name of tomb whose hooks belong
 #					   mount tomb
 list_tomb_binds() {
-	[[ -z "$2" ]] && {
+	[[ -z "$1" ]] && {
 		_failure "Internal error: list_tomb_binds called without argument." }
 
 	# much simpler than the crazy from before
 	# in fact, the second parameter is now redundant
-	# as we only need the tomb name
-
-	# note that this code assumes that the tomb name is provided in square brackets
-
-	_sudo findmnt -ro SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
-		| grep -F "/dev/mapper/tomb" \
-		| awk -vpattern="$1" '
-BEGIN { }
+	# as we only need the tomb mapper name
+	findmnt --source=/dev/mapper/"$1" -rno SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
+		| awk '
 {
-  if("["$5"]"!=pattern) next;
   if(index($1,"[")==0) next;
-  gsub("[[][^]]*[]]","",$1);
   print $1 ";" $2 ";" $3 ";(" $4 ");[" $5 "]"
 }
 '
@@ -3064,7 +3057,7 @@ umount_tomb() {
 				 $tombname "$tombmount"
 
 		# check if there are bind mounted dirs and close them
-		bind_tombs=(`list_tomb_binds $tombname "$tombmount"`)
+		bind_tombs=(`list_tomb_binds "$mapper"`)
 		for b in ${bind_tombs}; do
 			bind_mapper="${b[(ws:;:)1]}"
 			bind_mount="${b[(ws:;:)2]}"

--- a/tomb
+++ b/tomb
@@ -3162,7 +3162,7 @@ slam_tomb() {
 				result=1 }
 		done
 		# if it failed killing a process, report it
-		[[ $result = 0 ]] && umount_tomb $tombname
+		[[ $result = 0 ]] && umount_tomb "${tombname:1:-1}"
 	done
 	return $result
 }
@@ -3378,7 +3378,7 @@ main() {
 
 		# Slam a tomb killing all processes running inside
 		slam)
-			slam_tomb $PARAM
+			slam_tomb $PARAM[1]
 			;;
 
 		# Close the tomb

--- a/tomb
+++ b/tomb
@@ -2756,34 +2756,18 @@ awk "/mapper/"' { print $2 ";" $3 ";" $4 ";" $5 }'`
 #
 # 5. tomb name
 list_tomb_mounts() {
-	[[ -z "$1" ]] && {
-		# list all open tombs
-		_sudo findmnt -rvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
+	# execute in subshell to avoid ZSH non-POSIX behaviour if globbing doesn't match something
+	( for dev in /dev/mapper/tomb*$1.*; do
+		findmnt --source ${dev} -rnvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
 			| awk '
 BEGIN { main="" }
-/^\/dev\/mapper\/tomb/ {
+{
   if(main==$1) next;
   print $1 ";" $2 ";" $3 ";(" $4 ");[" $5 "]"
   main=$1
 }
 '
-	} || {
-		# list a specific tomb
-		# add square parens if not present (detection)
-		local tname
-		if [[ "${1[1]}" = "[" ]]; then tname="$1"
-		else tname="[$1]"; fi
-		_sudo findmnt -rvo SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
-			| awk -vtomb="$tname" '
-BEGIN { main="" }
-/^\/dev\/mapper\/tomb/ {
-  if("["$5"]"!=tomb) next;
-  if(main==$1) next;
-  print $1 ";" $2 ";" $3 ";(" $4 ");[" $5 "]"
-  main=$1
-}
-'
-	}
+	done ) 2>/dev/null
 }
 
 # list_tomb_binds

--- a/tomb
+++ b/tomb
@@ -2779,13 +2779,12 @@ list_tomb_binds() {
 	[[ -z "$1" ]] && {
 		_failure "Internal error: list_tomb_binds called without argument." }
 
-	# much simpler than the crazy from before
-	# in fact, the second parameter is now redundant
-	# as we only need the tomb mapper name
+	# ignore the first line of the result for the respective source (mapper),
+	# as this will be the canonical first mount (aka main mount)
 	findmnt --source=/dev/mapper/"$1" -rno SOURCE,TARGET,FSTYPE,OPTIONS,LABEL \
 		| awk '
+FNR==1 {next}
 {
-  if(index($1,"[")==0) next;
   print $1 ";" $2 ";" $3 ";(" $4 ");[" $5 "]"
 }
 '
@@ -3056,7 +3055,8 @@ umount_tomb() {
 		_message "Closing tomb ::1 tomb name:: mounted on ::2 mount point::" \
 				 $tombname "$tombmount"
 
-		# check if there are bind mounted dirs and close them
+		# check if there are bind mounted dirs and close them first
+		# Can be due to bind-hooks or outside --bind mounts
 		bind_tombs=(`list_tomb_binds "$mapper"`)
 		for b in ${bind_tombs}; do
 			bind_mapper="${b[(ws:;:)1]}"
@@ -3066,27 +3066,14 @@ umount_tomb() {
 				_failure "Tomb bind hook ::1 hook:: is busy, cannot close tomb." "$bind_mount"
 		done
 
-		# check if the tomb is actually still mounted. Background:
-		# When mounted on a binded directory in appears twice in 'list_tomb_binds'
-		# and will get umounted automatically through the above function
-		# causing an error and a remaining (decrypted!) loop device
-		# posing a security risk.
-		# See https://github.com/dyne/Tomb/issues/273
-
-		# checking for tombs still mounted
-		mounted_tombs=(`list_tomb_mounts`)
-		for t in ${mounted_tombs}; do
-			usedmount=${t[(ws:;:)2]}
-			[[ "$usedmount" == "$tombmount" ]] && {
-				_verbose "Performing umount of ::1 mount point::" "$tombmount"
-				touch "${tombmount}"/.cleanexit
-				_sudo umount "${tombmount}"
-				[[ $? = 0 ]] || {
-					rm -f "${tombmount}"/.cleanexit
-					_failure "Tomb is busy, cannot umount!"
-				}
-			}
-		done
+		# umount the main mount
+		_verbose "Performing umount of ::1 mount point::" "$tombmount"
+		touch "${tombmount}"/.cleanexit
+		_sudo umount "${tombmount}"
+		[[ $? = 0 ]] || {
+			rm -f "${tombmount}"/.cleanexit
+			_failure "Tomb is busy, cannot umount!"
+		}
 
 		# If we used a default mountpoint and is now empty, delete it
 		tombname_regex=${tombname//\[/}


### PR DESCRIPTION
Cryptsetup is since 1.3.0 capable of setting up a loop device if the device argument is a file.
This has the additional benefit that those loop devices will get the AUTOCLEAR flag (available with Linux 2.6.25). This means those loop devices will be closed as soon their're unused (on luksClose).
_____________________
Read about something unrelated, stumbled upon cryptsetup usage without explicit losetup fiddling and thought maybe this is something for tomb to adopt.

Alternatively `lo_preserve()` could be dropped and respective changes at other places still could apply. `losetup -d` removes devices lazily. If it cannot be closed it won't report `EBUSY` anymore, but instead set `AUTOCLEAR` (since Linux 3.7). Status can be seen via `losetup --list`.

Would be nice to get rid of `lo_mount` (now `lo_check`), but such a change would change behaviour (e.g. mapper name).

Things to check: If the comment from `umount_tomb`
https://github.com/dyne/tomb/blob/75aafc0c8c6eacfbd7035ecf2a731dd7447f9dde/tomb#L3117-L3122
would still apply with the suggested changes