### PR TITLE
Rework slam function

### DIFF
--- a/tomb
+++ b/tomb
@@ -3004,22 +3004,24 @@ umount_tomb() {
 list_processes() {
 	# $1 = (optional) name of tomb
 	# runs lsof on the mounted_tombs
-	local mounted_tombs i
+	local mounted_tombs i indicator lsofres
+	indicator=1 # != 0 means there were processes
 	mounted_tombs=(`list_tomb_mounts $1`)
 	if [[ "${#mounted_tombs}" -gt 0 ]]; then
 		if [[ -z $1 ]]; then
-			_success "Listing processes running inside all open tombs..."
+			_success "Looking for processes running inside all open tombs..."
 		else
-			_success "Listing processes running inside tomb '::1 tombname::'..." "$1"
+			_success "Looking for processes running inside tomb '::1 tombname::'..." "$1"
 		fi
 
 		for i in ${mounted_tombs}; do
 			_verbose "scanning tomb: ::1 tombmount::" $i
-			tombmount="${i[(ws:;:)2]}"
-			_sudo lsof +D "${i[(ws:;:)2]}"
+			lsofres=$(_sudo lsof +D "${i[(ws:;:)2]}")
+			# Check on output, as $? will always return 1 for whatever reasons
+			[[ -n $lsofres ]] && { indicator=0; echo $lsofres } || { _success "None found" }
 		done
 	fi
-	return 0
+	return $indicator
 }
 
 # Kill all processes using the tomb
@@ -3040,7 +3042,7 @@ slam_tomb() {
 		_warning "or issue the command 'tomb close all' to close them all."
 		_failure "Operation aborted." }
 
-	local pnum puid pcmd powner result
+	local pnum result lsofres
 	result=0
 	# iterate through all mounted tomb affected
 	for i in ${mounted_tombs}; do
@@ -3048,28 +3050,32 @@ slam_tomb() {
 		tombmount="${i[(ws:;:)2]}"
 		_success "Slamming tomb ::1 tombname:: mounted on ::2 tombmount::" \
 				 ${tombname} "${tombmount}"
-		# iterate through all processes running in mounted tombs
-		for pnum in ${(f)"$(_sudo lsof -t +D "$tombmount")"}; do
-			puid=$(cat /proc/${pnum}/loginuid)
-			pcmd=$(cat /proc/${pnum}/cmdline)
-			powner=`_get_username $puid`
-			_verbose "process found: $pnum $pcmd ($powner)"
-			# iterate through 3 different signals to send, break on success
+		list_processes "${tombname:1:-1}"
+		[[ $? -eq 0 ]] && {
+			# iterate through 3 different signals, break on success
 			for s in TERM HUP KILL; do
-				_message "::1 tombname:: sending ::2 sig:: to ::3 cmd:: (::4 uid::)" \
-						 ${tombname} ${s} ${pcmd} ${powner}
-				_sudo kill -$s $pnum
+				lsofres=(`_sudo lsof -t +D "$tombmount"`)
+				[[ -n $lsofres ]] && {
+					# iterate through all processes before switching signals
+					for pnum in $lsofres; do
+						_message "::1 tombname:: sending ::2 sig:: to open process ::3 pnum::" \
+								 ${tombname} ${s} ${pnum}
+						_sudo kill -$s $pnum
+					done
+				} || { break }
 				# give some time to the process for a clean quit
 				sleep .5
-				# stop sending other signals if kill was succesfull
-				[[ -r /proc/$pnum ]] || break
 			done
-			# if process still running then signal failure
-			[[ -r /proc/$pnum ]] && {
-				_warning "Can't kill ::1 process:: ::2 pcmd:: (::3 powner::)" \
-						 $pnum $pcmd $powner
-				result=1 }
-		done
+		}
+
+		# if there are still processes then signal failure
+		lsofres=(`_sudo lsof -t +D "$tombmount"`)
+		[[ -n $lsofres ]] && {
+			for pnum in $lsofres; do
+				_warning "Couldn't kill ::1 pnum::" $pnum
+			done
+			result=1
+		}
 		# if it failed killing a process, report it
 		[[ $result = 0 ]] && umount_tomb "${tombname:1:-1}"
 	done

--- a/tomb
+++ b/tomb
@@ -64,6 +64,7 @@ typeset -i DECLOAKIFY=1
 typeset -i RESIZER=1
 typeset -i RECOLL=1
 typeset -i QRENCODE=1
+typeset -i LSOF=1
 
 # Default mount options
 typeset		 MOUNTOPTS="rw,noatime,nodev"
@@ -2961,8 +2962,18 @@ umount_tomb() {
 			}
 		}
 
-		_message "Closing tomb ::1 tomb name:: mounted on ::2 mount point::" \
+		# if SLAM is set kill possible processes
+		[[ -v SLAM ]] && {
+			_message "Slamming tomb ::1 tombname:: mounted on ::2 tombmount::" \
+				 ${tombname} "${tombmount}"
+			_kill_processes "$tombname" "$tombmount"
+			[[ $? -ne 0 ]] && {
+				_failure "Still active processes for ::1 tombname ::, cannot close tomb." "$tombname"
+			}
+		} || {
+			_message "Closing tomb ::1 tomb name:: mounted on ::2 mount point::" \
 				 $tombname "$tombmount"
+		}
 
 		# check if there are bind mounted dirs and close them first
 		# Can be due to bind-hooks or outside --bind mounts
@@ -3006,12 +3017,12 @@ list_processes() {
 	# runs lsof on the mounted_tombs
 	local mounted_tombs i indicator lsofres
 	indicator=1 # != 0 means there were processes
-	mounted_tombs=(`list_tomb_mounts $1`)
+	mounted_tombs=(`list_tomb_mounts ${1//[\[\]]/}`) # remove possible []
 	if [[ "${#mounted_tombs}" -gt 0 ]]; then
 		if [[ -z $1 ]]; then
-			_success "Looking for processes running inside all open tombs..."
+			_message "Looking for processes running inside all open tombs..."
 		else
-			_success "Looking for processes running inside tomb '::1 tombname::'..." "$1"
+			_message "Looking for processes running inside tomb ::1 tombname::..." "$1"
 		fi
 
 		for i in ${mounted_tombs}; do
@@ -3024,61 +3035,45 @@ list_processes() {
 	return $indicator
 }
 
-# Kill all processes using the tomb
-slam_tomb() {
-	# $1 = (optional) name of tomb to slam, or "all" if more mounted
-
-	if [ "$1" = "all" ]; then
-		mounted_tombs=(`list_tomb_mounts`)
-	else
-		mounted_tombs=(`list_tomb_mounts $1`)
-	fi
-
-	[[ ${#mounted_tombs} == 0 ]] && {
-		_failure "There is no open tomb to be closed." }
-
-	[[ ${#mounted_tombs} -gt 1 && -z "$1" ]] && {
-		_warning "Too many tombs mounted, please specify one (see tomb list)"
-		_warning "or issue the command 'tomb close all' to close them all."
-		_failure "Operation aborted." }
+# Kill all processes using the specified tomb
+_kill_processes() {
+	# $1 = name of tomb to slam
+	# $2 = mount location of tomb
+	[[ -z "$2" ]] && _failure "Missing arguments for slamming."
 
 	local pnum result lsofres
 	result=0
-	# iterate through all mounted tomb affected
-	for i in ${mounted_tombs}; do
-		tombname=${i[(ws:;:)5]}
-		tombmount="${i[(ws:;:)2]}"
-		_success "Slamming tomb ::1 tombname:: mounted on ::2 tombmount::" \
-				 ${tombname} "${tombmount}"
-		list_processes "${tombname:1:-1}"
-		[[ $? -eq 0 ]] && {
-			# iterate through 3 different signals, break on success
-			for s in TERM HUP KILL; do
-				lsofres=(`_sudo lsof -t +D "$tombmount"`)
-				[[ -n $lsofres ]] && {
-					# iterate through all processes before switching signals
-					for pnum in $lsofres; do
-						_message "::1 tombname:: sending ::2 sig:: to open process ::3 pnum::" \
-								 ${tombname} ${s} ${pnum}
-						_sudo kill -$s $pnum
-					done
-				} || { break }
-				# give some time to the process for a clean quit
-				sleep .5
-			done
-		}
 
-		# if there are still processes then signal failure
-		lsofres=(`_sudo lsof -t +D "$tombmount"`)
-		[[ -n $lsofres ]] && {
-			for pnum in $lsofres; do
-				_warning "Couldn't kill ::1 pnum::" $pnum
-			done
-			result=1
-		}
-		# if it failed killing a process, report it
-		[[ $result = 0 ]] && umount_tomb "${tombname:1:-1}"
-	done
+	_verbose "::1 tombname:: Determining if there are open processes that needs killing" "$1"
+
+	list_processes "$1"
+	[[ $? -eq 0 ]] && {
+		_verbose "Found open processes in ::1 tombname::" "$1"
+		# iterate through 3 different signals, break on success
+		for s in TERM HUP KILL; do
+			lsofres=(`_sudo lsof -t +D "$2"`)
+			[[ -n $lsofres ]] && {
+				# iterate through all processes before switching signals
+				for pnum in $lsofres; do
+					_message "::1 tombname:: sending ::2 sig:: to open process ::3 pnum::" \
+							 ${1} ${s} ${pnum}
+					_sudo kill -$s $pnum
+				done
+				} || { break }
+			# give some time to the process for a clean quit
+			sleep .5
+		done
+	}
+
+	# if there are still processes then signal failure
+	lsofres=(`_sudo lsof -t +D "$tombmount"`)
+	[[ -n $lsofres ]] && {
+		_verbose "Verify that no open processes remain in ::1 tombname::" "$1"
+		for pnum in $lsofres; do
+			_warning "Couldn't kill ::1 pnum::" $pnum
+		done
+		result=1
+	}
 	return $result
 }
 
@@ -3293,18 +3288,15 @@ main() {
 
 		# Slam a tomb killing all processes running inside
 		slam)
-			slam_tomb $PARAM[1]
-			;;
+			[[ $LSOF -eq 1 ]] && {
+				SLAM=1
+			} || {
+				_warning "lsof not installed: cannot slam tombs."
+				_warning "Trying a regular close."}
+			;&
 
 		# Close the tomb
-		# `slam` is used to force closing.
 		umount|close)
-			[[ "$subcommand" == "slam" ]] && {
-				SLAM=1
-				[[ $LSOF == 0 ]] && {
-					unset SLAM
-					_warning "lsof not installed: cannot slam tombs."
-					_warning "Trying a regular close." }}
 			umount_tomb $PARAM[1]
 			;;
 


### PR DESCRIPTION
Two things get in this PR addressed:

## Commit 1:
### slam_tomb(): don't parse process output and rework

In https://github.com/dyne/tomb/pull/504 list_processes() got reworked in a way to avoid parsing process
output as this had interesting side-effects.
Back then I mentioned the same behaviour existing in slam_tomb() which
should probably be changed too. This PR addresses that.
Firstly it will use list_processes() from within slam_tomb(), as this is
in principal overlapping functionality. For this list_processes() needed
to be adjusted. It now has a return value which can indicate if there
were processes.
Secondly the order of execution was changed in slam_tomb(). Before it
would process one process and work through the signals until this
process was killed. Now it will take a signal and issue a kill for all
processes found.

## Commit 2:
### slam_tomb: simplify and rename to _kill_processes

In general umount_tomb and slam_tomb shared a lot of similar code.
Main difference being, that the latter additionally searched for
processes and would still call umount_tomb if the processes could
be killed.
umount_tomb would then again search with the provided name for the
relevant tomb in list_tomb_mounts, which should be obsolete at this
point.
Therefore the decision to reduce slam_tomb in functionality. It would
only work on a supplied tombname and tombmount, look if there are
processes and is called from within umount_tomb.
(Theoretical tombname could be removed)
Calling tomb with slam or close sets a flag, which will decide if
that part in umount_tomb will be executed.

____________________
And the final PR for the time being :) 