### PR TITLE
change egrep to grep -E

### DIFF
--- a/tomb
+++ b/tomb
@@ -386,7 +386,7 @@ _is_encrypted_block() {
 	[[ $? -eq 0 ]] && s="--inverse"
 
 	_sudo lsblk $s -o type -n $b 2>/dev/null \
-		| egrep -q '^crypt$'
+		| grep -Eq '^crypt$'
 
 	return $?
 }


### PR DESCRIPTION
egrep and fgrep are deemed obsolete and usage issues a warning since a few versions. To quote the respective notification:
7th Edition Unix had commands egrep and fgrep that were the counterparts of the modern ‘grep -E’ and ‘grep -F’. Although breaking up grep into three programs was perhaps useful on the small computers of the 1970s, egrep and fgrep were deemed obsolescent by POSIX in 1992, removed from POSIX in 2001, deprecated by GNU Grep 2.5.3 in 2007, and changed to issue obsolescence warnings by GNU Grep 3.8 in 2022; eventually, they are planned to be removed entirely.

Closes #553