### PR TITLE
Address unexpected output to stdout in ask_password()

### DIFF
--- a/tomb
+++ b/tomb
@@ -522,7 +522,7 @@ ask_password() {
 				;;
 		esac
 	fi
-	_verbose "Checking backends '${backends[@]}'"
+	_verbose "Checking backends '${backends}'"
 
 	for backend in "${backends[@]}"; do
 		pinentry="$(which pinentry-$backend)"

--- a/tomb
+++ b/tomb
@@ -490,12 +490,9 @@ ask_password() {
 
 	local description="$1"
 	local title="${2:-Enter tomb password.}"
-	local output
-	local password
-	local gtkrc
-	local theme
-	local pass_asked
-	local backends
+	local output password pinentry lddout
+	local -i pass_asked=0
+	local -a backends
 
 	# Distributions have broken wrappers for pinentry: they do
 	# implement fallback, but they disrupt the output somehow.	We are
@@ -511,8 +508,6 @@ ask_password() {
 	LANG=${LANG:-C}
 
 	_verbose "asking password with tty=$TTY lc-ctype=$LANG"
-
-	pass_asked=0
 
 	# Guess preferred backend based on environment.
 	backends=(curses tty)
@@ -530,8 +525,7 @@ ask_password() {
 	_verbose "Checking backends '${backends[@]}'"
 
 	for backend in "${backends[@]}"; do
-		local pinentry="$(which pinentry-$backend)"
-		local lddout
+		pinentry="$(which pinentry-$backend)"
 		lddout=$(ldd "$pinentry" 2>/dev/null) || continue
 		[[ "$lddout" == *'not found'* ]] && continue
 		_verbose "using $pinentry"

--- a/tomb
+++ b/tomb
@@ -56,6 +56,10 @@ zmodload -F zsh/stat b:zstat
 # make sure variables aren't exported
 unsetopt allexport
 
+# Don't print variables to STDOUT if local/typeset is used
+# on an already existing variable without an assignment
+setopt TYPESET_SILENT
+
 # Flag optional commands if available (see _ensure_dependencies())
 typeset -i KDF=1
 typeset -i STEGHIDE=1
@@ -526,9 +530,8 @@ ask_password() {
 	_verbose "Checking backends '${backends[@]}'"
 
 	for backend in "${backends[@]}"; do
-		local pinentry
+		local pinentry="$(which pinentry-$backend)"
 		local lddout
-		pinentry="$(which pinentry-$backend)"
 		lddout=$(ldd "$pinentry" 2>/dev/null) || continue
 		[[ "$lddout" == *'not found'* ]] && continue
 		_verbose "using $pinentry"


### PR DESCRIPTION
Contains the fix for #575 plus some cleanup to `ask_password()`.
What every changeset does is best retrieved from the respective commit messages.
As this can affect a lot of people I suggest a new release after that issue got addressed. For example every distribution with a qt6 based DE will run into this, as `pinentry-qt5` may not be available.