### PR TITLE
Fix typo in manual page

### DIFF
--- a/doc/tomb.1
+++ b/doc/tomb.1
@@ -287,7 +287,7 @@ trusted keys in GPG.
 .B
 .IP "--kdf \fI[argon2 | pbkdf2]\fR"
 Enable the KDF feature against dictionary attacks when creating a key.
-The required argument currently allows to choose between \fIargon2\fR
+The required argument currently allows one to choose between \fIargon2\fR
 or \fIpbkdf2\fR.
 \fIargon2\fR is using a mix of RAM capacity, number of threads and
 iterations to achieve a time cost.


### PR DESCRIPTION
Debian's lint tool complained about "allows to" in line 291, instead "allows one to" would be correct.