### PR TITLE
Add option --pinentry

### DIFF
--- a/doc/tomb.1
+++ b/doc/tomb.1
@@ -329,6 +329,12 @@ Select a different tool than sudo for privilege escalation.
 Alternatives supported so far are: pkexec, doas, sup, sud. For any
 alternative to work the executable must be included in the current
 PATH.
+.B
+.IP "--pinentry \fI<toolkit>\fR"
+Add a \fIpinentry\fR which is tried first for usage. Allows to force a specific
+one or the use of an alternative not listed (like bemenu or wayprompt).
+Important: It needs to be a drop-in replacement for \fIpinentry\fR. It doesn't allow
+for a different architecture of password input.
 
 .B
 .IP "-h"
@@ -435,10 +441,13 @@ To avoid that tomb execution is logged by \fIsyslog\fR also add:
 .SH PASSWORD INPUT
 
 Password input is handled by the pinentry program: it can be text
-based or graphical and is usually configured with a symlink. When
-using Tomb in a graphical environment (X11 or Wayland) it is better
-to use either pinentry-gtk2 (deprecated), pinentry-gnome or
-pinentry-qt because it helps preventing keylogging by other clients.
+based or graphical. \fITomb\fR implements a logic to detect the
+preferred and working password input based on the environment (tty,
+X11 or Wayland).
+It is possible to specify a specific pinentry program which is tried
+first (\fI--pinentry tty\fR or \fI--pinentry=wayprompt\fR) but it
+should be avoided to use a text based one in a graphical environment
+as the graphical ones help preventing keylogging by other clients.
 When using it from a remote ssh connection it might be necessary to
 force use of pinentry-tty for instance by unsetting the DISPLAY (X11)
 or WAYLAND_DISPLAY (Wayland) environment var.

--- a/tomb
+++ b/tomb
@@ -500,27 +500,33 @@ ask_password() {
 	# fallback logic directly here.
 	# Pinentry supported: curses, tty, qt{,4,5}, gtk{,-2}, gnome3, and x11.
 
-	# TODO: Implement a user option to specify a pinentry program and
-	# wrap pinentry with a `_pinentry()` function that implements the
-	# search logic if the user option is not specified: Issue #542
+	# TODO: Wrap pinentry with a `_pinentry()` function that implements
+	# the search logic: Issue #542
 
 	# make sure LANG is set, default to C
 	LANG=${LANG:-C}
 
 	_verbose "asking password with tty=$TTY lc-ctype=$LANG"
 
-	# Guess preferred backend based on environment.
-	backends=(curses tty)
+	# Check for user specified pinentry
+	option_is_set --pinentry && {
+		backends+=`option_value --pinentry`
+		_verbose "Adding ::1 pinentry:: to pinentry backends" $backends[0]
+	}
+
+	# Guess and add preferred backends based on environment.
 	if [[ -n "$DISPLAY" || -n "$WAYLAND_DISPLAY" ]]; then
 		_verbose "Graphical display system detected"
 		case "$XDG_CURRENT_DESKTOP" in
 			KDE|LXQT|LXQt)
-				backends=(qt5 qt qt4 gnome3 gtk gtk-2 curses tty)
+				backends+=(qt5 qt qt4 gnome3 gtk gtk-2 curses tty)
 				;;
 			*)
-				backends=(gtk gtk-2 x11 gnome3 qt5 qt qt4 curses tty)
+				backends+=(gtk gtk-2 x11 gnome3 qt5 qt qt4 curses tty)
 				;;
 		esac
+	else
+		backends+=(curses tty)
 	fi
 	_verbose "Checking backends '${backends}'"
 
@@ -3136,7 +3142,7 @@ main() {
 	# can only use the non-abbreviated long-option version like:
 	# -force and NOT -f
 	#
-	main_opts=(q -quiet=q D -debug=D h -help=h v -version=v f -force=f -tmp: U: G: T: -no-color -unsafe g -gpgkey=g -sudo:)
+	main_opts=(q -quiet=q D -debug=D h -help=h v -version=v f -force=f -tmp: U: G: T: -no-color -unsafe g -gpgkey=g -sudo: -pinentry:)
 	subcommands_opts[__default]=""
 	# -o in open and mount is used to pass alternate mount options
 	subcommands_opts[open]="n -nohook=n k: o: -ignore-swap -tomb-pwd: r: R: p -preserve-ownership=p"


### PR DESCRIPTION
This allows to specify a specific pinentry program which is tried first while finding a working pinentry program.
For input is only the part needed after "pinentry-". This isn't a general option to specify something completly different as password input (yet).

The update to the manpage includes the new option and an update to the pinentry section. With the way how pinentry is nowadays detected, the manual force of a specific pinentry via symlink shouldn't be encouraged. And if a specific one should be used, one can use now the new option.
____________
Doesn't really help with the big ToDos in `ask_password()`, but allows in theory the usage of pinentries like `wayprompt` or `pinentry-bemenu`.
Did take a look into adding the wrapper.. but this is not a small change. Especially with all the possible corner cases.
And with the ToDo in regards to use `read -s -r` as a fallback... this needs some more thinking.