### PR TITLE
Rework logic in `_sudo()` and add support for  `sudo-rs`

### DIFF
--- a/doc/tomb.1
+++ b/doc/tomb.1
@@ -325,8 +325,8 @@ takes massively longer on regular systems.
 Default is 1 thread (based on the \fIargon2\fR default).
 .B
 .IP "--sudo \fI<executable>\fR"
-Select a different tool than sudo for privilege escalation.
-Alternatives supported so far are: pkexec, doas, sup, sud. For any
+Select a different tool than sudo or doas for privilege escalation.
+Alternatives supported so far are: pkexec, sup, sud. For any
 alternative to work the executable must be included in the current
 PATH.
 
@@ -419,7 +419,8 @@ user. Tomb executes as super user only when required.
 
 To be made available on multi user systems, the superuser execution of
 the tomb script can be authorized for users without jeopardizing the
-whole system's security: just add such a line to \fI/etc/sudoers\fR:
+whole system's security: In case of sudo just add such a line to
+\fI/etc/sudoers\fR:
 
 .EX
 	username ALL=NOPASSWD: /usr/local/bin/tomb
@@ -431,6 +432,8 @@ To avoid that tomb execution is logged by \fIsyslog\fR also add:
 	Cmnd_Alias TOMB = /usr/local/bin/tomb
 	Defaults!TOMB !syslog
 .EE
+
+Different tools require other settings to achieve something similar.
 
 .SH PASSWORD INPUT
 

--- a/doc/tomb.1
+++ b/doc/tomb.1
@@ -326,7 +326,7 @@ Default is 1 thread (based on the \fIargon2\fR default).
 .B
 .IP "--sudo \fI<executable>\fR"
 Select a different tool than sudo or doas for privilege escalation.
-Alternatives supported so far are: pkexec, sup, sud. For any
+Alternatives supported so far are: pkexec, sup, sud, sudo-rs. For any
 alternative to work the executable must be included in the current
 PATH.
 

--- a/tomb
+++ b/tomb
@@ -151,6 +151,9 @@ _sudo() {
 $msg
 ")
 			;;
+		"sudo-rs")
+			pe_extras=("-p" "$msg")
+			;;
 		"doas"|"sup"|"sud"|"pkexec")
 			;;
 		*)

--- a/tomb
+++ b/tomb
@@ -139,29 +139,29 @@ _sudo() {
 		esac
 
 	else
-    if [[ "`id -u`" = "0" ]]; then
+		if [[ "`id -u`" = "0" ]]; then
 			_verbose "Super user execution skipped (SUID caller)"
 			${@}
 			return $?
-    elif _is_found sudo; then
-		  local msg="[sudo] Enter password for user ::1 user:: to gain superuser privileges"
-		  _is_found gettext && msg="$(gettext -s "$msg")"
-		  msg=${(S)msg//::1*::/$USER}
-		  [[ -n "$SUDO_ASKPASS" ]] && local sudo_askpass="--askpass"
-		  sudo $sudo_askpass -p "
+		elif _is_found sudo; then
+			local msg="[sudo] Enter password for user ::1 user:: to gain superuser privileges"
+			_is_found gettext && msg="$(gettext -s "$msg")"
+			msg=${(S)msg//::1*::/$USER}
+			[[ -n "$SUDO_ASKPASS" ]] && local sudo_askpass="--askpass"
+			sudo $sudo_askpass -p "
 $msg
 
 " ${@}
-		  return $?
-    elif _is_found doas; then
-		  local msg="Enter password for user ::1 user:: to gain superuser privileges"
-		  _is_found gettext && msg="$(gettext -s "$msg")"
-		  msg=${(S)msg//::1*::/$USER}
-      doas ${@}
-      return $?
-    else
-      _failure "No way found to escalate privileges to super user."
-    fi
+			return $?
+		elif _is_found doas; then
+			local msg="Enter password for user ::1 user:: to gain superuser privileges"
+			_is_found gettext && msg="$(gettext -s "$msg")"
+			msg=${(S)msg//::1*::/$USER}
+			doas ${@}
+			return $?
+		else
+			_failure "No way found to escalate privileges to super user."
+		fi
 	fi
 }
 

--- a/tomb
+++ b/tomb
@@ -118,51 +118,50 @@ export TEXTDOMAIN=tomb
 
 # Wrap sudo with a more visible message or apply user-supplied alternative to sudo
 _sudo() {
-	if option_is_set --sudo; then
-		pescmd=`option_value --sudo`
-		case `basename $pescmd` in
-			"doas"|"sup"|"sud"|"pkexec")
+	local -a pescmds pe_extras
+	local pescmd
 
-				_is_found $pescmd || _failure "::1 pesc:: executable not found" $pescmd
- 				_verbose "Super user execution using ::1 pesc::" $pescmd
-				${pescmd} ${@}
-				return $?
-				;;
-			"skip"|"none")
-				_verbose "Super user execution skipped (SUID caller)"
-				${@}
-				return $?
-				;;
-			 *)
-				_failure "Super user execution not supported: ::1 sudo::" "`option_value --sudo`"
-				;;
-		esac
+	[[ "`id -u`" = "0" ]] && {
+		_verbose "Super user execution skipped (SUID caller)"
+		${@}
+		return $?
+	}
 
-	else
-		if [[ "`id -u`" = "0" ]]; then
-			_verbose "Super user execution skipped (SUID caller)"
-			${@}
-			return $?
-		elif _is_found sudo; then
-			local msg="[sudo] Enter password for user ::1 user:: to gain superuser privileges"
-			_is_found gettext && msg="$(gettext -s "$msg")"
-			msg=${(S)msg//::1*::/$USER}
+	option_is_set --sudo && {
+		pescmds=(`option_value --sudo`)
+	}
+	pescmds+=("sudo" "doas")
+
+	for cmd in "${pescmds[@]}"; do
+		_is_found $cmd && { pescmd=$cmd; break }
+	done
+	[[ -z ${pescmd} ]] &&
+		_failure "Couldn't find a viable privilege escalation tool."
+
+	# Construct message for the tools that allow custom prompts
+	local msg="Enter password for user ::1 user:: to gain superuser privileges"
+	_is_found gettext && msg="$(gettext -s "$msg")"
+	msg=${(S)msg//::1*::/$USER}
+
+	# Adjust call in regards of the chosen tool
+	case `basename $pescmd` in
+		"sudo")
 			[[ -n "$SUDO_ASKPASS" ]] && local sudo_askpass="--askpass"
-			sudo $sudo_askpass -p "
+			pe_extras=("-p" "
 $msg
+")
+			;;
+		"doas"|"sup"|"sud"|"pkexec")
+			;;
+		*)
+			_failure "Super user execution not supported: ::1 sudo::" "`option_value --sudo`"
+			;;
+	esac
 
-" ${@}
-			return $?
-		elif _is_found doas; then
-			local msg="Enter password for user ::1 user:: to gain superuser privileges"
-			_is_found gettext && msg="$(gettext -s "$msg")"
-			msg=${(S)msg//::1*::/$USER}
-			doas ${@}
-			return $?
-		else
-			_failure "No way found to escalate privileges to super user."
-		fi
-	fi
+	# Execute stuff
+	_verbose "Super user execution using ::1 pesc::" $pescmd
+	${pescmd} $sudo_askpass $pe_extras ${@}
+	return $?
 }
 
 # Cleanup anything sensitive before exiting.


### PR DESCRIPTION
The `sudo` wrapper `_sudo` has different behaviour depending if `--sudo` is  used or not. It is more chatty with `-D`, `--sudo sudo` doesn't work and code duplications which could theoretically be avoided.
Therefore an attempt to make the function more general and instead of the two branches just provide one. The logic itself is inspired by the structure from the `_pinentry` wrapper.

And add support for [`sudo-rs`](https://github.com/trifectatechfoundation/sudo-rs)

Not sure adding the verbosity in general... It is rather chatty, but also a reminder for all those places were privilege escalation is needed :D 