### PR TITLE
Change password input for gpg operations

### DIFF
--- a/tomb
+++ b/tomb
@@ -571,7 +571,7 @@ ask_password() {
 		return 1
 	}
 
-	print "$password"
+	print -R -n - "$password"
 	return 0
 }
 
@@ -1154,10 +1154,10 @@ _load_key() {
 gpg_decrypt() {
 	# gpg version check necessary for <2.1.x (although those aren't supported anymore)
 	local gpgver=$(gpg --version --no-permission-warning | awk '/^gpg/ {print $3}')
-	local gpgpass="$1\n$TOMBKEY"
+	local gpgpass="$1"
 	local tmpres ret
 	typeset -a gpgopt
-	gpgpopt=(--batch --no-tty --passphrase-fd 0 --no-options)
+	gpgpopt=(--batch --no-tty --no-options --no-mdc-warning --no-permission-warning --no-secmem-warning)
 
 	{ option_is_set -g } && {
 		gpgpass="$TOMBKEY"
@@ -1176,10 +1176,9 @@ gpg_decrypt() {
 
 	_tmp_create
 	tmpres=$TOMBTMP
-	TOMBSECRET=`print - "$gpgpass" | \
-		gpg --decrypt ${gpgpopt[@]} \
-			--status-fd 2 --no-mdc-warning --no-permission-warning \
-			--no-secmem-warning 2> $tmpres`
+	TOMBSECRET=`print - "$TOMBKEY" | \
+		gpg --decrypt ${gpgpopt[@]} --status-fd 2  \
+			--passphrase-file <(print -R -n - "$gpgpass") 2> $tmpres`
 	unset gpgpass
 	ret=1
 	for i in ${(f)"$(cat $tmpres)"}; do
@@ -1528,18 +1527,16 @@ gen_key() {
 		print $header >> "$1"
 
 		# Set gpg inputs and options
-		gpgpass="${tombpass}\n$TOMBSECRET"
 		gpgopt=(--passphrase-fd 0 --symmetric --no-options)
 		opt='-n'
 	fi
 
 	_tmp_create
 	local tmpres=$TOMBTMP
-	print $opt - "$gpgpass" \
+	print $opt - "$TOMBSECRET" \
 		| gpg --openpgp --force-mdc --cipher-algo ${algo} \
-			  --batch --no-tty ${gpgopt} \
+			  --batch --no-tty ${gpgopt} --passphrase-file <(print -R -n - "$tombpass") \
 			  --status-fd 2 -o - --armor 2> $tmpres >> "$1"
-	unset gpgpass
 	# check result of gpg operation
 	for i in ${(f)"$(cat $tmpres)"}; do
 		_verbose "$i"

--- a/tomb
+++ b/tomb
@@ -1152,7 +1152,7 @@ _load_key() {
 # contains tweaks for different gpg versions
 # support both symmetric and asymmetric encryption
 gpg_decrypt() {
-	# fix for gpg 1.4.11 where the --status-* options don't work ;^/
+	# gpg version check necessary for <2.1.x (although those aren't supported anymore)
 	local gpgver=$(gpg --version --no-permission-warning | awk '/^gpg/ {print $3}')
 	local gpgpass="$1\n$TOMBKEY"
 	local tmpres ret
@@ -1174,15 +1174,6 @@ gpg_decrypt() {
 		}
 	}
 
-	[[ $gpgver == "1.4.11" ]] && {
-		_verbose "GnuPG is version 1.4.11 - adopting status fix."
-		TOMBSECRET=`print - "$gpgpass" | \
-			gpg --decrypt ${gpgpopt[@]}`
-		ret=$?
-		unset gpgpass
-		return $ret
-	}
-
 	_tmp_create
 	tmpres=$TOMBTMP
 	TOMBSECRET=`print - "$gpgpass" | \
@@ -1196,7 +1187,6 @@ gpg_decrypt() {
 		[[ "$i" =~ "DECRYPTION_OKAY" ]] && ret=0;
 	done
 	return $ret
-
 }
 
 


### PR DESCRIPTION
Creating as draft, as this needs to be thoroughly tested and checked and isn't finished/cleaned up yet.
If finished the commit messages will be updated to include the issues it closes (if any...).
____________________
Background of this PR is the issue that `tomb` has issues with passwords that try to use characters in a combination so they create control sequences for the shell. For example newline `\n`, form feed `\f` and tabulator `\t`.
This is due how the password is provided for the `gpg` call. `gpg` is used with `--passphrase-fd 0` which reads the password from STDIN until it encounters a newline. Unfortunately this means the shell interprets those character sequences in the password itself. Especially fatal in case of `\n` as this will reduce the password to this point. Example: you want to set password `test\ntest`. gpg, while reading `STDIN`, will stop at `\n` and the resulting password will be only `test`.
Not sure yet what happens with the rest, but it does seem to be discarded in general and not added to or used as `TOMBSECRET`.

Two ways to avoid interpreting control sequences:
* change `--passphrase-fd` to a dedicated descriptor above 2 (like `--passphrase-fd 3` and input password like `3<<<"$password"`
* use `--passphrase-file` and use an anonymous pipe (how it is done with this PR)

In general the first option is similar to the current solution. But is untested if the redirect isn't visible while tracing. But I will also create a draft with that solution. Makes it easier to compare and check by others.
The second option uses an option which is discouraged. But the anonymous pipe should address concerns in regard to that.