### PR TITLE
fido2: fix hmac-secret detection with comma-separated libfido2 output

### DIFF
--- a/tomb
+++ b/tomb
@@ -1122,6 +1122,7 @@ _fido2_require_extension() {
 		if [[ "${(L)line}" == "extension strings:"* ]]; then
 			line=${line#*:}
 			for word in ${(s: :)line}; do
+				word=${word%,}   # libfido2 comma-separates extensions
 				[[ "$word" == "$ext" ]] && return 0
 			done
 		fi


### PR DESCRIPTION
## Problem

tomb forge --fido2 fails on compatible authenticators with:

[E] FIDO2 authenticator does not advertise hmac-secret. Please enable
    hmac-secret on the key or use a compatible device.
even when the device clearly supports it:

$ fido2-token -I /dev/hidraw3
...
extension strings: credProtect, hmac-secret, largeBlobKey, credBlob, minPinLength
## Root cause

_fido2_require_extension() parses that line by splitting on spaces only. Modern libfido2 (>= 1.15) prints the extension list comma-separated, so each word keeps a trailing comma (hmac-secret,) and never matches the target extension name. Only the last entry in the list
(no trailing comma) can ever match, so the check almost always fails.

## Fix

Strip a trailing comma from each word before comparing. Works for both the comma-separated (new) and space-separated (old) formats, so no version detection is needed:

for word in ${(s: :)line}; do
    word=${word%,}   # libfido2 comma-separates extensions
    [[ "$word" == "$ext" ]] && return 0
done
## Testing

- Before: tomb forge --fido2 -k test.key --fido2-device /dev/hidraw3 aborts with the hmac-secret error.
- After: the extension is detected and forging proceeds.

Environment: Tomb 2.13.0, libfido2 1.16.0, YubiKey 5 (FIDO_2_1), Linux.
